### PR TITLE
Enable generic pricing for AD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ name = "fixedratepricing"
 [[example]]
 name = "floatingratepricing"
 
+[[example]]
+name = "ad_time_sensitivity"
+

--- a/examples/ad_time_sensitivity.rs
+++ b/examples/ad_time_sensitivity.rs
@@ -1,0 +1,17 @@
+extern crate rustatlas;
+
+use rustatlas::math::ad::{backward, reset_tape, Var};
+use rustatlas::utils::num::FloatOps;
+
+fn main() {
+    reset_tape();
+    let r = Var::new(0.05);
+    let t = Var::new(2.0);
+    // discount factor = exp(-r * t)
+    let df = (-r * t).exp();
+    let grad = backward(&df);
+
+    println!("discount factor: {}", df.value());
+    println!("d(df)/d(r): {}", grad[r.id()]);
+    println!("d(df)/d(t): {}", grad[t.id()]);
+}

--- a/src/core/meta.rs
+++ b/src/core/meta.rs
@@ -185,24 +185,24 @@ impl MarketRequest {
 /// * `fwd` - The forward rate.
 /// * `fx` - The exchange rate.
 #[derive(Debug, Clone, Copy)]
-pub struct MarketData {
+pub struct MarketData<T = f64> {
     id: usize,
     reference_date: Date,
-    df: Option<f64>,
-    fwd: Option<f64>,
-    fx: Option<f64>,
-    numerarie: f64,
+    df: Option<T>,
+    fwd: Option<T>,
+    fx: Option<T>,
+    numerarie: T,
 }
 
-impl MarketData {
+impl<T> MarketData<T> {
     pub fn new(
         id: usize,
         reference_date: Date,
-        df: Option<f64>,
-        fwd: Option<f64>,
-        fx: Option<f64>,
-        numerarie: f64,
-    ) -> MarketData {
+        df: Option<T>,
+        fwd: Option<T>,
+        fx: Option<T>,
+        numerarie: T,
+    ) -> MarketData<T> {
         MarketData {
             id,
             reference_date,
@@ -220,21 +220,23 @@ impl MarketData {
     pub fn reference_date(&self) -> Date {
         self.reference_date
     }
+}
 
-    pub fn df(&self) -> Result<f64> {
+impl<T: Copy> MarketData<T> {
+    pub fn df(&self) -> Result<T> {
         self.df.ok_or(AtlasError::ValueNotSetErr("df".to_string()))
     }
 
-    pub fn fwd(&self) -> Result<f64> {
+    pub fn fwd(&self) -> Result<T> {
         self.fwd
             .ok_or(AtlasError::ValueNotSetErr("fwd".to_string()))
     }
 
-    pub fn fx(&self) -> Result<f64> {
+    pub fn fx(&self) -> Result<T> {
         self.fx.ok_or(AtlasError::ValueNotSetErr("fx".to_string()))
     }
 
-    pub fn numerarie(&self) -> f64 {
+    pub fn numerarie(&self) -> T {
         self.numerarie
     }
 }

--- a/src/models/simplemodel.rs
+++ b/src/models/simplemodel.rs
@@ -39,11 +39,12 @@ impl<'a> SimpleModel<'a> {
 }
 
 impl<'a> Model for SimpleModel<'a> {
+    type Num = f64;
     fn reference_date(&self) -> Date {
         self.market_store.reference_date()
     }
 
-    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<f64> {
+    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<Self::Num> {
         let date = df.date();
         let ref_date = self.market_store.reference_date();
 
@@ -60,7 +61,7 @@ impl<'a> Model for SimpleModel<'a> {
         Ok(curve.discount_factor(date)?)
     }
 
-    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<f64> {
+    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<Self::Num> {
         let id = fwd.provider_id();
         let end_date = fwd.end_date();
         let ref_date = self.market_store.reference_date();
@@ -79,11 +80,11 @@ impl<'a> Model for SimpleModel<'a> {
         )?)
     }
 
-    fn gen_numerarie(&self, _: &crate::prelude::MarketRequest) -> Result<f64> {
+    fn gen_numerarie(&self, _: &crate::prelude::MarketRequest) -> Result<Self::Num> {
         Ok(1.0)
     }
 
-    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<f64> {
+    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<Self::Num> {
         let first_currency = fx.first_currency();
         let second_currency = match fx.second_currency() {
             Some(ccy) => ccy,

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -1,14 +1,15 @@
-use crate::{core::meta::*, time::date::Date, utils::errors::Result};
+use crate::{core::meta::*, time::date::Date, utils::{errors::Result, num::Real}};
 
 /// # Model
 /// A model that provides market data based in the current market state.
 pub trait Model {
+    type Num: Real;
     fn reference_date(&self) -> Date;
-    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<f64>;
-    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<f64>;
-    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<f64>;
-    fn gen_numerarie(&self, market_request: &MarketRequest) -> Result<f64>;
-    fn gen_node(&self, market_request: &MarketRequest) -> Result<MarketData> {
+    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<Self::Num>;
+    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<Self::Num>;
+    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<Self::Num>;
+    fn gen_numerarie(&self, market_request: &MarketRequest) -> Result<Self::Num>;
+    fn gen_node(&self, market_request: &MarketRequest) -> Result<MarketData<Self::Num>> {
         let id = market_request.id();
         let df = match market_request.df() {
             Some(df) => Some(self.gen_df_data(df)?),
@@ -37,7 +38,7 @@ pub trait Model {
         ));
     }
 
-    fn gen_market_data(&self, market_request: &[MarketRequest]) -> Result<Vec<MarketData>> {
+    fn gen_market_data(&self, market_request: &[MarketRequest]) -> Result<Vec<MarketData<Self::Num>>> {
         market_request.iter().map(|x| self.gen_node(x)).collect()
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod errors;
 pub mod tools;
+pub mod num;

--- a/src/utils/num.rs
+++ b/src/utils/num.rs
@@ -1,0 +1,39 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+/// Trait implemented by numeric types used in pricing calculations.
+pub trait Real:
+    Copy + Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self> + Div<Output = Self> + Neg<Output = Self> + From<f64>
+{
+}
+
+impl<T> Real for T where
+    T: Copy
+        + Add<Output = T>
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Neg<Output = T>
+        + From<f64>
+{
+}
+
+/// Floating point specific operations needed for differentiation
+pub trait FloatOps: Real {
+    fn exp(self) -> Self;
+    fn ln(self) -> Self;
+    fn powf(self, n: f64) -> Self;
+}
+
+impl FloatOps for f64 {
+    fn exp(self) -> Self {
+        f64::exp(self)
+    }
+
+    fn ln(self) -> Self {
+        f64::ln(self)
+    }
+
+    fn powf(self, n: f64) -> Self {
+        f64::powf(self, n)
+    }
+}


### PR DESCRIPTION
## Summary
- add generic Real trait and implement for f64/Var
- expose value on `Var` and implement conversions
- make `MarketData` and `Model` generic over numeric type
- adapt `SimpleModel` and `NPVConstVisitor` to work generically
- add `FloatOps` trait with `exp`, `ln`, `powf` and implement for `Var`
- example `ad_time_sensitivity` demonstrates derivative of a discount factor

## Testing
- `cargo test --quiet`
