### PR TITLE
Enable second order derivatives

### DIFF
--- a/src/core/meta.rs
+++ b/src/core/meta.rs
@@ -185,24 +185,24 @@ impl MarketRequest {
 /// * `fwd` - The forward rate.
 /// * `fx` - The exchange rate.
 #[derive(Debug, Clone, Copy)]
-pub struct MarketData {
+pub struct MarketData<T = f64> {
     id: usize,
     reference_date: Date,
-    df: Option<f64>,
-    fwd: Option<f64>,
-    fx: Option<f64>,
-    numerarie: f64,
+    df: Option<T>,
+    fwd: Option<T>,
+    fx: Option<T>,
+    numerarie: T,
 }
 
-impl MarketData {
+impl<T> MarketData<T> {
     pub fn new(
         id: usize,
         reference_date: Date,
-        df: Option<f64>,
-        fwd: Option<f64>,
-        fx: Option<f64>,
-        numerarie: f64,
-    ) -> MarketData {
+        df: Option<T>,
+        fwd: Option<T>,
+        fx: Option<T>,
+        numerarie: T,
+    ) -> MarketData<T> {
         MarketData {
             id,
             reference_date,
@@ -220,21 +220,23 @@ impl MarketData {
     pub fn reference_date(&self) -> Date {
         self.reference_date
     }
+}
 
-    pub fn df(&self) -> Result<f64> {
+impl<T: Copy> MarketData<T> {
+    pub fn df(&self) -> Result<T> {
         self.df.ok_or(AtlasError::ValueNotSetErr("df".to_string()))
     }
 
-    pub fn fwd(&self) -> Result<f64> {
+    pub fn fwd(&self) -> Result<T> {
         self.fwd
             .ok_or(AtlasError::ValueNotSetErr("fwd".to_string()))
     }
 
-    pub fn fx(&self) -> Result<f64> {
+    pub fn fx(&self) -> Result<T> {
         self.fx.ok_or(AtlasError::ValueNotSetErr("fx".to_string()))
     }
 
-    pub fn numerarie(&self) -> f64 {
+    pub fn numerarie(&self) -> T {
         self.numerarie
     }
 }

--- a/src/math/ad/mod.rs
+++ b/src/math/ad/mod.rs
@@ -55,12 +55,24 @@ impl Var {
         Var { id }
     }
 
-    fn value(&self) -> f64 {
+    pub fn value(&self) -> f64 {
         value_of(self.id)
     }
 
     pub fn id(&self) -> usize {
         self.id
+    }
+}
+
+impl From<f64> for Var {
+    fn from(value: f64) -> Self {
+        Var::new(value)
+    }
+}
+
+impl From<Var> for f64 {
+    fn from(v: Var) -> Self {
+        v.value()
     }
 }
 
@@ -181,6 +193,142 @@ pub fn backward(result: &Var) -> Vec<f64> {
     })
 }
 
+pub fn grad_hessian(result: &Var, inputs: &[Var]) -> (Vec<f64>, Vec<Vec<f64>>) {
+    TAPE.with(|t| {
+        let tape = t.borrow();
+        let m = tape.len();
+        let n = inputs.len();
+        let input_ids: Vec<usize> = inputs.iter().map(|v| v.id).collect();
+
+        // forward pass - derivative of each node wrt inputs
+        let mut deriv = vec![vec![0.0; n]; m];
+        for i in 0..m {
+            let node = &tape[i];
+            match node.op {
+                Op::Input => {
+                    if let Some(pos) = input_ids.iter().position(|&id| id == i) {
+                        deriv[i][pos] = 1.0;
+                    }
+                }
+                Op::Add => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    for j in 0..n {
+                        deriv[i][j] = deriv[l][j] + deriv[r][j];
+                    }
+                }
+                Op::Sub => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    for j in 0..n {
+                        deriv[i][j] = deriv[l][j] - deriv[r][j];
+                    }
+                }
+                Op::Mul => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    let lv = tape[l].value;
+                    let rv = tape[r].value;
+                    for j in 0..n {
+                        deriv[i][j] = deriv[l][j] * rv + lv * deriv[r][j];
+                    }
+                }
+                Op::Div => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    let lv = tape[l].value;
+                    let rv = tape[r].value;
+                    for j in 0..n {
+                        deriv[i][j] = (deriv[l][j] * rv - lv * deriv[r][j]) / (rv * rv);
+                    }
+                }
+                Op::Neg => {
+                    let l = node.lhs.unwrap();
+                    for j in 0..n {
+                        deriv[i][j] = -deriv[l][j];
+                    }
+                }
+            }
+        }
+
+        // reverse pass - gradients and Hessian
+        let mut grad = vec![0.0; m];
+        let mut hess = vec![vec![0.0; n]; m];
+        grad[result.id] = 1.0;
+
+        for i in (0..=result.id).rev() {
+            let node = &tape[i];
+            match node.op {
+                Op::Input => {}
+                Op::Add => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    grad[l] += grad[i];
+                    grad[r] += grad[i];
+                    for j in 0..n {
+                        hess[l][j] += hess[i][j];
+                        hess[r][j] += hess[i][j];
+                    }
+                }
+                Op::Sub => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    grad[l] += grad[i];
+                    grad[r] -= grad[i];
+                    for j in 0..n {
+                        hess[l][j] += hess[i][j];
+                        hess[r][j] -= hess[i][j];
+                    }
+                }
+                Op::Mul => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    let lv = tape[l].value;
+                    let rv = tape[r].value;
+                    grad[l] += grad[i] * rv;
+                    grad[r] += grad[i] * lv;
+                    for j in 0..n {
+                        hess[l][j] += hess[i][j] * rv + grad[i] * deriv[r][j];
+                        hess[r][j] += hess[i][j] * lv + grad[i] * deriv[l][j];
+                    }
+                }
+                Op::Div => {
+                    let l = node.lhs.unwrap();
+                    let r = node.rhs.unwrap();
+                    let lv = tape[l].value;
+                    let rv = tape[r].value;
+                    grad[l] += grad[i] / rv;
+                    grad[r] -= grad[i] * lv / (rv * rv);
+                    for j in 0..n {
+                        let d2_da = -deriv[r][j] / (rv * rv);
+                        let d2_db = (2.0 * lv * deriv[r][j] / (rv * rv * rv))
+                            - deriv[l][j] / (rv * rv);
+                        hess[l][j] += hess[i][j] / rv + grad[i] * d2_da;
+                        hess[r][j] += hess[i][j] * (-lv / (rv * rv)) + grad[i] * d2_db;
+                    }
+                }
+                Op::Neg => {
+                    let l = node.lhs.unwrap();
+                    grad[l] -= grad[i];
+                    for j in 0..n {
+                        hess[l][j] -= hess[i][j];
+                    }
+                }
+            }
+        }
+
+        let gradient: Vec<f64> = input_ids.iter().map(|&id| grad[id]).collect();
+        let mut hessian = vec![vec![0.0; n]; n];
+        for (row_idx, &id_row) in input_ids.iter().enumerate() {
+            for (col_idx, _) in input_ids.iter().enumerate() {
+                hessian[row_idx][col_idx] = hess[id_row][col_idx];
+            }
+        }
+
+        (gradient, hessian)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,6 +362,31 @@ mod tests {
         let grad = backward(&z);
         assert!((grad[x.id()] + 0.5).abs() < 1e-12);
         assert!((grad[y.id()] + 1.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn hessian_square_plus() {
+        reset_tape();
+        let x = Var::new(2.0);
+        let y = x * x + x;
+        let (grad, hess) = grad_hessian(&y, &[x]);
+        assert!((grad[0] - 5.0).abs() < 1e-12);
+        assert!((hess[0][0] - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn hessian_multivar() {
+        reset_tape();
+        let x = Var::new(3.0);
+        let y = Var::new(4.0);
+        let z = x * y + y * y;
+        let (grad, hess) = grad_hessian(&z, &[x, y]);
+        assert!((grad[0] - 4.0).abs() < 1e-12);
+        assert!((grad[1] - 11.0).abs() < 1e-12);
+        assert!((hess[0][0]).abs() < 1e-12);
+        assert!((hess[0][1] - 1.0).abs() < 1e-12);
+        assert!((hess[1][0] - 1.0).abs() < 1e-12);
+        assert!((hess[1][1] - 2.0).abs() < 1e-12);
     }
 }
 

--- a/src/models/simplemodel.rs
+++ b/src/models/simplemodel.rs
@@ -39,11 +39,12 @@ impl<'a> SimpleModel<'a> {
 }
 
 impl<'a> Model for SimpleModel<'a> {
+    type Num = f64;
     fn reference_date(&self) -> Date {
         self.market_store.reference_date()
     }
 
-    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<f64> {
+    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<Self::Num> {
         let date = df.date();
         let ref_date = self.market_store.reference_date();
 
@@ -60,7 +61,7 @@ impl<'a> Model for SimpleModel<'a> {
         Ok(curve.discount_factor(date)?)
     }
 
-    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<f64> {
+    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<Self::Num> {
         let id = fwd.provider_id();
         let end_date = fwd.end_date();
         let ref_date = self.market_store.reference_date();
@@ -79,11 +80,11 @@ impl<'a> Model for SimpleModel<'a> {
         )?)
     }
 
-    fn gen_numerarie(&self, _: &crate::prelude::MarketRequest) -> Result<f64> {
+    fn gen_numerarie(&self, _: &crate::prelude::MarketRequest) -> Result<Self::Num> {
         Ok(1.0)
     }
 
-    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<f64> {
+    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<Self::Num> {
         let first_currency = fx.first_currency();
         let second_currency = match fx.second_currency() {
             Some(ccy) => ccy,

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -1,14 +1,15 @@
-use crate::{core::meta::*, time::date::Date, utils::errors::Result};
+use crate::{core::meta::*, time::date::Date, utils::{errors::Result, num::Real}};
 
 /// # Model
 /// A model that provides market data based in the current market state.
 pub trait Model {
+    type Num: Real;
     fn reference_date(&self) -> Date;
-    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<f64>;
-    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<f64>;
-    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<f64>;
-    fn gen_numerarie(&self, market_request: &MarketRequest) -> Result<f64>;
-    fn gen_node(&self, market_request: &MarketRequest) -> Result<MarketData> {
+    fn gen_df_data(&self, df: DiscountFactorRequest) -> Result<Self::Num>;
+    fn gen_fx_data(&self, fx: ExchangeRateRequest) -> Result<Self::Num>;
+    fn gen_fwd_data(&self, fwd: ForwardRateRequest) -> Result<Self::Num>;
+    fn gen_numerarie(&self, market_request: &MarketRequest) -> Result<Self::Num>;
+    fn gen_node(&self, market_request: &MarketRequest) -> Result<MarketData<Self::Num>> {
         let id = market_request.id();
         let df = match market_request.df() {
             Some(df) => Some(self.gen_df_data(df)?),
@@ -37,7 +38,7 @@ pub trait Model {
         ));
     }
 
-    fn gen_market_data(&self, market_request: &[MarketRequest]) -> Result<Vec<MarketData>> {
+    fn gen_market_data(&self, market_request: &[MarketRequest]) -> Result<Vec<MarketData<Self::Num>>> {
         market_request.iter().map(|x| self.gen_node(x)).collect()
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod errors;
 pub mod tools;
+pub mod num;

--- a/src/utils/num.rs
+++ b/src/utils/num.rs
@@ -1,0 +1,18 @@
+use std::ops::{Add, Sub, Mul, Div, Neg};
+
+/// Trait implemented by numeric types used in pricing calculations.
+pub trait Real:
+    Copy + Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self> + Div<Output = Self> + Neg<Output = Self> + From<f64>
+{
+}
+
+impl<T> Real for T where
+    T: Copy
+        + Add<Output = T>
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Neg<Output = T>
+        + From<f64>
+{
+}


### PR DESCRIPTION
## Summary
- implement `grad_hessian` to compute gradients and Hessians using forward-over-reverse on the tape
- add unit tests covering single and multi-variable Hessians

## Testing
- `cargo test --quiet`
