### PR TITLE
Add `#[must_use]` and `const fn` annotations across the codebase

### DIFF
--- a/src/cashflows/fixedratecoupon.rs
+++ b/src/cashflows/fixedratecoupon.rs
@@ -45,6 +45,7 @@ impl FixedRateCoupon {
     /// * `payment_date` - The date on which the coupon is paid
     /// * `currency` - The currency of the coupon
     /// * `side` - Whether this is a Pay or Receive side
+    #[must_use]
     pub fn new(
         notional: f64,
         rate: InterestRate,
@@ -66,6 +67,7 @@ impl FixedRateCoupon {
     }
 
     /// Sets the discount curve ID and returns self for method chaining.
+    #[must_use]
     pub fn with_discount_curve_id(mut self, id: usize) -> Self {
         self.cashflow.set_discount_curve_id(id);
         self
@@ -105,12 +107,14 @@ impl FixedRateCoupon {
     }
 
     /// Returns the notional amount.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the interest rate.
-    pub fn rate(&self) -> InterestRate {
+    #[must_use]
+    pub const fn rate(&self) -> InterestRate {
         self.rate
     }
 }

--- a/src/cashflows/floatingratecoupon.rs
+++ b/src/cashflows/floatingratecoupon.rs
@@ -47,6 +47,7 @@ pub struct FloatingRateCoupon {
 
 impl FloatingRateCoupon {
     /// Creates a new floating rate coupon with the specified parameters.
+    #[must_use]
     pub fn new(
         notional: f64,
         spread: f64,
@@ -72,13 +73,15 @@ impl FloatingRateCoupon {
     }
 
     /// Sets the discount curve ID and returns the modified coupon.
+    #[must_use]
     pub fn with_discount_curve_id(mut self, id: usize) -> Self {
         self.cashflow = self.cashflow.with_discount_curve_id(id);
         self
     }
 
     /// Sets the forecast curve ID and returns the modified coupon.
-    pub fn with_forecast_curve_id(mut self, id: usize) -> Self {
+    #[must_use]
+    pub const fn with_forecast_curve_id(mut self, id: usize) -> Self {
         self.forecast_curve_id = Some(id);
         self
     }
@@ -89,7 +92,7 @@ impl FloatingRateCoupon {
     }
 
     /// Sets the forecast curve ID.
-    pub fn set_forecast_curve_id(&mut self, id: usize) {
+    pub const fn set_forecast_curve_id(&mut self, id: usize) {
         self.forecast_curve_id = Some(id);
     }
 
@@ -103,27 +106,31 @@ impl FloatingRateCoupon {
     }
 
     /// Sets the notional amount.
-    pub fn set_notional(&mut self, notional: f64) {
+    pub const fn set_notional(&mut self, notional: f64) {
         self.notional = notional;
     }
 
     /// Returns the notional amount.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the spread.
-    pub fn spread(&self) -> f64 {
+    #[must_use]
+    pub const fn spread(&self) -> f64 {
         self.spread
     }
 
     /// Returns the rate definition.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Returns the fixing date, or the accrual start date if no fixing date is set.
-    pub fn fixing_date(&self) -> Date {
+    #[must_use]
+    pub const fn fixing_date(&self) -> Date {
         match self.fixing_date {
             Some(date) => date,
             None => self.accrual_start_date,
@@ -131,7 +138,8 @@ impl FloatingRateCoupon {
     }
 
     /// Returns the fixing rate if set.
-    pub fn fixing_rate(&self) -> Option<f64> {
+    #[must_use]
+    pub const fn fixing_rate(&self) -> Option<f64> {
         self.fixing_rate
     }
 }

--- a/src/cashflows/simplecashflow.rs
+++ b/src/cashflows/simplecashflow.rs
@@ -36,7 +36,8 @@ pub struct SimpleCashflow {
 
 impl SimpleCashflow {
     /// Creates a new `SimpleCashflow` with the given payment date, currency, and side.
-    pub fn new(payment_date: Date, currency: Currency, side: Side) -> SimpleCashflow {
+    #[must_use]
+    pub const fn new(payment_date: Date, currency: Currency, side: Side) -> SimpleCashflow {
         Self {
             payment_date,
             currency,
@@ -49,32 +50,35 @@ impl SimpleCashflow {
 
     /// Sets the amount for this cashflow and returns self for method chaining.
     #[must_use]
-    pub fn with_amount(mut self, amount: f64) -> Self {
+    #[must_use]
+    pub const fn with_amount(mut self, amount: f64) -> Self {
         self.amount = Some(amount);
         self
     }
 
+    #[must_use]
     /// Sets the discount curve ID for this cashflow and returns self for method chaining.
     #[must_use]
-    pub fn with_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
+    pub const fn with_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
         self.discount_curve_id = Some(discount_curve_id);
         self
     }
+#[must_use]
 
     /// Sets the registry ID for this cashflow and returns self for method chaining.
     #[must_use]
-    pub fn with_id(mut self, registry_id: usize) -> Self {
+    pub const fn with_id(mut self, registry_id: usize) -> Self {
         self.id = Some(registry_id);
         self
     }
 
     /// Sets the discount curve ID for this cashflow.
-    pub fn set_discount_curve_id(&mut self, id: usize) {
+    pub const fn set_discount_curve_id(&mut self, id: usize) {
         self.discount_curve_id = Some(id);
     }
 
     /// Sets the amount for this cashflow.
-    pub fn set_amount(&mut self, amount: f64) {
+    pub const fn set_amount(&mut self, amount: f64) {
         self.amount = Some(amount);
     }
 }

--- a/src/core/marketstore.rs
+++ b/src/core/marketstore.rs
@@ -49,29 +49,29 @@ impl MarketStore {
 
     /// Returns the local currency of this market store.
     #[must_use]
-    pub fn local_currency(&self) -> Currency {
+    pub const fn local_currency(&self) -> Currency {
         self.local_currency
     }
 
     /// Returns a reference to the exchange rate store.
     #[must_use]
-    pub fn exchange_rate_store(&self) -> &ExchangeRateStore {
+    pub const fn exchange_rate_store(&self) -> &ExchangeRateStore {
         &self.exchange_rate_store
     }
 
     /// Returns a mutable reference to the exchange rate store.
-    pub fn mut_exchange_rate_store(&mut self) -> &mut ExchangeRateStore {
+    pub const fn mut_exchange_rate_store(&mut self) -> &mut ExchangeRateStore {
         &mut self.exchange_rate_store
     }
 
     /// Returns a reference to the index store.
     #[must_use]
-    pub fn index_store(&self) -> &IndexStore {
+    pub const fn index_store(&self) -> &IndexStore {
         &self.index_store
     }
 
     /// Returns a mutable reference to the index store.
-    pub fn mut_index_store(&mut self) -> &mut IndexStore {
+    pub const fn mut_index_store(&mut self) -> &mut IndexStore {
         &mut self.index_store
     }
 

--- a/src/core/meta.rs
+++ b/src/core/meta.rs
@@ -22,7 +22,8 @@ pub struct ExchangeRateRequest {
 
 impl ExchangeRateRequest {
     /// Creates a new `ExchangeRateRequest`.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         first_currency: Currency,
         second_currency: Option<Currency>,
         reference_date: Option<Date>,
@@ -35,17 +36,20 @@ impl ExchangeRateRequest {
     }
 
     /// Returns the first currency.
-    pub fn first_currency(&self) -> Currency {
+    #[must_use]
+    pub const fn first_currency(&self) -> Currency {
         self.first_currency
     }
 
     /// Returns the second currency.
-    pub fn second_currency(&self) -> Option<Currency> {
+    #[must_use]
+    pub const fn second_currency(&self) -> Option<Currency> {
         self.second_currency
     }
 
     /// Returns the reference date.
-    pub fn reference_date(&self) -> Option<Date> {
+    #[must_use]
+    pub const fn reference_date(&self) -> Option<Date> {
         self.reference_date
     }
 }
@@ -65,17 +69,20 @@ pub struct DiscountFactorRequest {
 
 impl DiscountFactorRequest {
     /// Creates a new `DiscountFactorRequest`.
-    pub fn new(provider_id: usize, date: Date) -> DiscountFactorRequest {
+    #[must_use]
+    pub const fn new(provider_id: usize, date: Date) -> DiscountFactorRequest {
         DiscountFactorRequest { provider_id, date }
     }
 
     /// Returns the provider id.
-    pub fn provider_id(&self) -> usize {
+    #[must_use]
+    pub const fn provider_id(&self) -> usize {
         self.provider_id
     }
 
     /// Returns the date.
-    pub fn date(&self) -> Date {
+    #[must_use]
+    pub const fn date(&self) -> Date {
         self.date
     }
 }
@@ -102,7 +109,8 @@ pub struct ForwardRateRequest {
 
 impl ForwardRateRequest {
     /// Creates a new `ForwardRateRequest`.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         provider_id: usize,
         fixing_date: Date,
         start_date: Date,
@@ -121,27 +129,32 @@ impl ForwardRateRequest {
     }
 
     /// Returns the provider id.
-    pub fn provider_id(&self) -> usize {
+    #[must_use]
+    pub const fn provider_id(&self) -> usize {
         self.provider_id
     }
 
     /// Returns the start date.
-    pub fn start_date(&self) -> Date {
+    #[must_use]
+    pub const fn start_date(&self) -> Date {
         self.start_date
     }
 
     /// Returns the end date.
-    pub fn end_date(&self) -> Date {
+    #[must_use]
+    pub const fn end_date(&self) -> Date {
         self.end_date
     }
 
     /// Returns the compounding.
-    pub fn compounding(&self) -> Compounding {
+    #[must_use]
+    pub const fn compounding(&self) -> Compounding {
         self.compounding
     }
 
     /// Returns the frequency.
-    pub fn frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn frequency(&self) -> Frequency {
         self.frequency
     }
 }
@@ -164,7 +177,8 @@ pub struct MarketRequest {
 
 impl MarketRequest {
     /// Creates a new `MarketRequest`.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         id: usize,
         df: Option<DiscountFactorRequest>,
         fwd: Option<ForwardRateRequest>,
@@ -174,22 +188,26 @@ impl MarketRequest {
     }
 
     /// Returns the id.
-    pub fn id(&self) -> usize {
+    #[must_use]
+    pub const fn id(&self) -> usize {
         self.id
     }
 
     /// Returns the discount factor request.
-    pub fn df(&self) -> Option<DiscountFactorRequest> {
+    #[must_use]
+    pub const fn df(&self) -> Option<DiscountFactorRequest> {
         self.df
     }
 
     /// Returns the forward rate request.
-    pub fn fwd(&self) -> Option<ForwardRateRequest> {
+    #[must_use]
+    pub const fn fwd(&self) -> Option<ForwardRateRequest> {
         self.fwd
     }
 
     /// Returns the exchange rate request.
-    pub fn fx(&self) -> Option<ExchangeRateRequest> {
+    #[must_use]
+    pub const fn fx(&self) -> Option<ExchangeRateRequest> {
         self.fx
     }
 }
@@ -214,7 +232,8 @@ pub struct MarketData {
 
 impl MarketData {
     /// Creates a new `MarketData`.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         id: usize,
         reference_date: Date,
         df: Option<f64>,
@@ -233,32 +252,35 @@ impl MarketData {
     }
 
     /// Returns the id.
-    pub fn id(&self) -> usize {
+    #[must_use]
+    pub const fn id(&self) -> usize {
         self.id
     }
 
     /// Returns the reference date.
-    pub fn reference_date(&self) -> Date {
+    #[must_use]
+    pub const fn reference_date(&self) -> Date {
         self.reference_date
     }
 
     /// Returns the discount factor.
-    pub fn df(&self) -> Result<f64> {
+    pub const fn df(&self) -> Result<f64> {
         self.df.ok_or(AtlasError::ValueNotSetErr("df".to_owned()))
     }
 
     /// Returns the forward rate.
-    pub fn fwd(&self) -> Result<f64> {
+    pub const fn fwd(&self) -> Result<f64> {
         self.fwd.ok_or(AtlasError::ValueNotSetErr("fwd".to_owned()))
     }
 
     /// Returns the exchange rate.
-    pub fn fx(&self) -> Result<f64> {
+    pub const fn fx(&self) -> Result<f64> {
         self.fx.ok_or(AtlasError::ValueNotSetErr("fx".to_owned()))
     }
 
     /// Returns the numeraire.
-    pub fn numerarie(&self) -> f64 {
+    #[must_use]
+    pub const fn numerarie(&self) -> f64 {
         self.numerarie
     }
 }

--- a/src/currencies/enums.rs
+++ b/src/currencies/enums.rs
@@ -64,6 +64,7 @@ pub enum Currency {
 impl Currency {
     /// Returns static metadata about the currency as
     /// (alphabetic code, display name, symbol, decimal precision, numeric ISO 4217 code).
+    #[must_use]
     pub const fn details(self) -> (&'static str, &'static str, &'static str, u8, u16) {
         match self {
             Self::USD => ("USD", "US Dollar", "$", 2, 840),
@@ -95,22 +96,27 @@ impl Currency {
     }
 
     /// Returns the alphabetic code of the currency.
+    #[must_use]
     pub const fn as_str(self) -> &'static str {
         self.details().0
     }
     /// Returns the display name of the currency.
+    #[must_use]
     pub const fn name(self) -> &'static str {
         self.details().1
     }
     /// Returns the symbol of the currency.
+    #[must_use]
     pub const fn symbol(self) -> &'static str {
         self.details().2
     }
     /// Returns the decimal precision of the currency.
+    #[must_use]
     pub const fn precision(self) -> u8 {
         self.details().3
     }
     /// Returns the numeric ISO 4217 code of the currency.
+    #[must_use]
     pub const fn numeric_code(self) -> u16 {
         self.details().4
     }

--- a/src/currencies/exchangeratestore.rs
+++ b/src/currencies/exchangeratestore.rs
@@ -27,6 +27,7 @@ pub struct ExchangeRateStore {
 
 impl ExchangeRateStore {
     /// Creates a new `ExchangeRateStore` with the given reference date.
+    #[must_use]
     pub fn new(date: Date) -> ExchangeRateStore {
         ExchangeRateStore {
             reference_date: date,
@@ -50,11 +51,13 @@ impl ExchangeRateStore {
     }
 
     /// Returns the reference date of this exchange rate store.
-    pub fn reference_date(&self) -> Date {
+    #[must_use]
+    pub const fn reference_date(&self) -> Date {
         self.reference_date
     }
 
     /// Returns a clone of the exchange rate map.
+    #[must_use]
     pub fn get_exchange_rate_map(&self) -> HashMap<(Currency, Currency), f64> {
         self.exchange_rate_map.clone()
     }

--- a/src/instruments/doublerateinstrument.rs
+++ b/src/instruments/doublerateinstrument.rs
@@ -42,7 +42,8 @@ pub struct DoubleRateInstrument {
 
 impl DoubleRateInstrument {
     /// Creates a new `DoubleRateInstrument` with the specified parameters.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         start_date: Date,
         end_date: Date,
         notional: f64,
@@ -85,98 +86,117 @@ impl DoubleRateInstrument {
     }
 
     /// Returns the notional amount of the instrument.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the notional amount at the rate change date, if specified.
+    #[must_use]
     pub const fn notional_at_change_rate(&self) -> Option<f64> {
         self.notional_at_change_rate
     }
 
     /// Returns the payment frequency of the instrument.
-    pub fn payment_frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn payment_frequency(&self) -> Frequency {
         self.payment_frequency
     }
 
     /// Returns the side (payer or receiver) of the instrument.
-    pub fn side(&self) -> Side {
+    #[must_use]
+    pub const fn side(&self) -> Side {
         self.side
     }
 
     /// Returns the identifier of the instrument, if specified.
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         self.id.clone()
     }
 
     /// Returns the forecast curve ID, if specified.
-    pub fn forecast_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn forecast_curve_id(&self) -> Option<usize> {
         self.forecast_curve_id
     }
 
     /// Returns the discount curve ID, if specified.
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         self.discount_curve_id
     }
 
     /// Returns the start date of the instrument.
-    pub fn start_date(&self) -> Date {
+    #[must_use]
+    pub const fn start_date(&self) -> Date {
         self.start_date
     }
 
     /// Returns the end date of the instrument.
-    pub fn end_date(&self) -> Date {
+    #[must_use]
+    pub const fn end_date(&self) -> Date {
         self.end_date
     }
 
     /// Returns the issue date of the instrument, if specified.
-    pub fn issue_date(&self) -> Option<Date> {
+    #[must_use]
+    pub const fn issue_date(&self) -> Option<Date> {
         self.issue_date
     }
 
     /// Returns the date when the interest rate changes.
-    pub fn change_rate_date(&self) -> Date {
+    #[must_use]
+    pub const fn change_rate_date(&self) -> Date {
         self.change_rate_date
     }
 
     /// Returns the type of interest rate applied.
-    pub fn rate_type(&self) -> RateType {
+    #[must_use]
+    pub const fn rate_type(&self) -> RateType {
         self.rate_type
     }
 
     /// Returns the rate definition for the first period.
-    pub fn first_rate_definition(&self) -> Option<RateDefinition> {
+    #[must_use]
+    pub const fn first_rate_definition(&self) -> Option<RateDefinition> {
         self.first_rate_definition
     }
 
     /// Returns the rate value for the first period, if specified.
-    pub fn first_rate(&self) -> Option<f64> {
+    #[must_use]
+    pub const fn first_rate(&self) -> Option<f64> {
         self.first_rate
     }
 
     /// Returns the rate definition for the second period.
-    pub fn second_rate_definition(&self) -> Option<RateDefinition> {
+    #[must_use]
+    pub const fn second_rate_definition(&self) -> Option<RateDefinition> {
         self.second_rate_definition
     }
 
     /// Returns the rate value for the second period, if specified.
-    pub fn second_rate(&self) -> Option<f64> {
+    #[must_use]
+    pub const fn second_rate(&self) -> Option<f64> {
         self.second_rate
     }
 
     /// Sets the discount curve ID and returns self for method chaining.
-    pub fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
+    #[must_use]
+    pub const fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
         self.discount_curve_id = Some(discount_curve_id);
         self
     }
 
     /// Sets the forecast curve ID and returns self for method chaining.
-    pub fn set_forecast_curve_id(mut self, forecast_curve_id: usize) -> Self {
+    #[must_use]
+    pub const fn set_forecast_curve_id(mut self, forecast_curve_id: usize) -> Self {
         self.forecast_curve_id = Some(forecast_curve_id);
         self
     }
 
     /// Sets the first rate for all cashflows before the rate change date.
+    #[must_use]
     pub fn set_first_rate(mut self, rate: f64) -> Self {
         let change_rate_date = self.change_rate_date();
         self.mut_cashflows().iter_mut().for_each(|cf| {
@@ -196,6 +216,7 @@ impl DoubleRateInstrument {
     }
 
     /// Sets the second rate for all cashflows after the rate change date.
+    #[must_use]
     pub fn set_second_rate(mut self, rate: f64) -> Self {
         let change_rate_date = self.change_rate_date();
         self.mut_cashflows().iter_mut().for_each(|cf| {
@@ -215,6 +236,7 @@ impl DoubleRateInstrument {
     }
 
     /// Sets both the first and second rates if provided.
+    #[must_use]
     pub fn set_rates(mut self, first_rate: Option<f64>, second_rate: Option<f64>) -> Self {
         if let Some(rate) = first_rate {
             self = self.set_first_rate(rate);

--- a/src/instruments/fixedrateinstrument.rs
+++ b/src/instruments/fixedrateinstrument.rs
@@ -43,7 +43,8 @@ pub struct FixedRateInstrument {
 
 impl FixedRateInstrument {
     /// Creates a new `FixedRateInstrument` with the specified parameters.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         start_date: Date,
         end_date: Date,
         notional: f64,
@@ -76,56 +77,67 @@ impl FixedRateInstrument {
     }
 
     /// Returns the identifier of this instrument.
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         self.id.clone()
     }
 
     /// Returns the start date of this instrument.
-    pub fn start_date(&self) -> Date {
+    #[must_use]
+    pub const fn start_date(&self) -> Date {
         self.start_date
     }
 
     /// Returns the end date (maturity) of this instrument.
-    pub fn end_date(&self) -> Date {
+    #[must_use]
+    pub const fn end_date(&self) -> Date {
         self.end_date
     }
 
     /// Returns the notional amount of this instrument.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the fixed interest rate of this instrument.
-    pub fn rate(&self) -> InterestRate {
+    #[must_use]
+    pub const fn rate(&self) -> InterestRate {
         self.rate
     }
 
     /// Returns the structure of this instrument.
-    pub fn structure(&self) -> Structure {
+    #[must_use]
+    pub const fn structure(&self) -> Structure {
         self.structure
     }
 
     /// Returns the payment frequency of this instrument.
-    pub fn payment_frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn payment_frequency(&self) -> Frequency {
         self.payment_frequency
     }
 
     /// Returns the identifier of the discount curve used for valuation.
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         self.discount_curve_id
     }
 
     /// Returns the side (pay or receive) of this instrument.
-    pub fn side(&self) -> Side {
+    #[must_use]
+    pub const fn side(&self) -> Side {
         self.side
     }
 
     /// Returns the issue date of this instrument.
-    pub fn issue_date(&self) -> Option<Date> {
+    #[must_use]
+    pub const fn issue_date(&self) -> Option<Date> {
         self.issue_date
     }
 
     /// Sets the discount curve identifier and updates all cashflows.
+    #[must_use]
     pub fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
         self.discount_curve_id = Some(discount_curve_id);
         self.mut_cashflows()
@@ -136,6 +148,7 @@ impl FixedRateInstrument {
     }
 
     /// Sets the interest rate and updates all fixed rate coupons.
+    #[must_use]
     pub fn set_rate(mut self, rate: InterestRate) -> Self {
         self.rate = rate;
         self.mut_cashflows().iter_mut().for_each(|cf| {

--- a/src/instruments/floatingrateinstrument.rs
+++ b/src/instruments/floatingrateinstrument.rs
@@ -48,7 +48,8 @@ pub struct FloatingRateInstrument {
 
 impl FloatingRateInstrument {
     /// Creates a new `FloatingRateInstrument`.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         start_date: Date,
         end_date: Date,
         notional: f64,
@@ -83,66 +84,79 @@ impl FloatingRateInstrument {
     }
 
     /// Returns the issue date.
-    pub fn issue_date(&self) -> Option<Date> {
+    #[must_use]
+    pub const fn issue_date(&self) -> Option<Date> {
         self.issue_date
     }
 
     /// Returns the identifier.
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         self.id.clone()
     }
 
     /// Returns the start date.
-    pub fn start_date(&self) -> Date {
+    #[must_use]
+    pub const fn start_date(&self) -> Date {
         self.start_date
     }
 
     /// Returns the end date.
-    pub fn end_date(&self) -> Date {
+    #[must_use]
+    pub const fn end_date(&self) -> Date {
         self.end_date
     }
 
     /// Returns the notional.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the spread.
-    pub fn spread(&self) -> f64 {
+    #[must_use]
+    pub const fn spread(&self) -> f64 {
         self.spread
     }
 
     /// Returns the side.
-    pub fn side(&self) -> Side {
+    #[must_use]
+    pub const fn side(&self) -> Side {
         self.side
     }
 
     /// Returns the payment frequency.
-    pub fn payment_frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn payment_frequency(&self) -> Frequency {
         self.payment_frequency
     }
 
     /// Returns the rate definition.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Returns the structure.
-    pub fn structure(&self) -> Structure {
+    #[must_use]
+    pub const fn structure(&self) -> Structure {
         self.structure
     }
 
     /// Returns the discount curve identifier.
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         self.discount_curve_id
     }
 
     /// Returns the forecast curve identifier.
-    pub fn forecast_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn forecast_curve_id(&self) -> Option<usize> {
         self.forecast_curve_id
     }
 
     /// Sets the discount curve identifier and updates all cashflows.
+    #[must_use]
     pub fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
         self.discount_curve_id = Some(discount_curve_id);
         self.mut_cashflows()
@@ -152,6 +166,7 @@ impl FloatingRateInstrument {
     }
 
     /// Sets the forecast curve identifier and updates all cashflows.
+    #[must_use]
     pub fn set_forecast_curve_id(mut self, forecast_curve_id: usize) -> Self {
         self.forecast_curve_id = Some(forecast_curve_id);
         self.mut_cashflows()
@@ -161,6 +176,7 @@ impl FloatingRateInstrument {
     }
 
     /// Sets the spread and updates all floating rate coupons.
+    #[must_use]
     pub fn set_spread(mut self, spread: f64) -> Self {
         self.spread = spread;
         self.mut_cashflows().iter_mut().for_each(|cf| {

--- a/src/instruments/hybridrateinstrument.rs
+++ b/src/instruments/hybridrateinstrument.rs
@@ -35,7 +35,8 @@ pub struct HybridRateInstrument {
 
 impl HybridRateInstrument {
     /// Creates a new hybrid rate instrument.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         start_date: Date,
         end_date: Date,
         notional: f64,
@@ -76,88 +77,105 @@ impl HybridRateInstrument {
     }
 
     /// Returns the notional amount of the instrument.
-    pub fn notional(&self) -> f64 {
+    #[must_use]
+    pub const fn notional(&self) -> f64 {
         self.notional
     }
 
     /// Returns the payment frequency of the instrument.
-    pub fn payment_frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn payment_frequency(&self) -> Frequency {
         self.payment_frequency
     }
 
     /// Returns the structure of the instrument.
-    pub fn structure(&self) -> Structure {
+    #[must_use]
+    pub const fn structure(&self) -> Structure {
         self.structure
     }
 
     /// Returns the side of the instrument.
-    pub fn side(&self) -> Option<Side> {
+    #[must_use]
+    pub const fn side(&self) -> Option<Side> {
         self.side
     }
 
     /// Returns the identifier of the instrument.
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         self.id.clone()
     }
 
     /// Returns the forecast curve identifier.
-    pub fn forecast_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn forecast_curve_id(&self) -> Option<usize> {
         self.forecast_curve_id
     }
 
     /// Returns the discount curve identifier.
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         self.discount_curve_id
     }
 
     /// Returns the start date of the instrument.
-    pub fn start_date(&self) -> Date {
+    #[must_use]
+    pub const fn start_date(&self) -> Date {
         self.start_date
     }
 
     /// Returns the end date of the instrument.
-    pub fn end_date(&self) -> Date {
+    #[must_use]
+    pub const fn end_date(&self) -> Date {
         self.end_date
     }
 
     /// Returns the issue date of the instrument.
-    pub fn issue_date(&self) -> Option<Date> {
+    #[must_use]
+    pub const fn issue_date(&self) -> Option<Date> {
         self.issue_date
     }
 
     /// Returns the rate type of the instrument.
-    pub fn rate_type(&self) -> RateType {
+    #[must_use]
+    pub const fn rate_type(&self) -> RateType {
         self.rate_type
     }
 
     /// Returns the first rate definition of the instrument.
-    pub fn first_rate_definition(&self) -> Option<RateDefinition> {
+    #[must_use]
+    pub const fn first_rate_definition(&self) -> Option<RateDefinition> {
         self.first_rate_definition
     }
 
     /// Returns the first rate of the instrument.
-    pub fn first_rate(&self) -> Option<f64> {
+    #[must_use]
+    pub const fn first_rate(&self) -> Option<f64> {
         self.first_rate
     }
 
     /// Returns the second rate definition of the instrument.
-    pub fn second_rate_definition(&self) -> Option<RateDefinition> {
+    #[must_use]
+    pub const fn second_rate_definition(&self) -> Option<RateDefinition> {
         self.second_rate_definition
     }
 
     /// Returns the second rate of the instrument.
-    pub fn second_rate(&self) -> Option<f64> {
+    #[must_use]
+    pub const fn second_rate(&self) -> Option<f64> {
         self.second_rate
     }
 
     /// Sets the discount curve identifier.
-    pub fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
+    #[must_use]
+    pub const fn set_discount_curve_id(mut self, discount_curve_id: usize) -> Self {
         self.discount_curve_id = Some(discount_curve_id);
         self
     }
 
     /// Sets the forecast curve identifier.
-    pub fn set_forecast_curve_id(mut self, forecast_curve_id: usize) -> Self {
+    #[must_use]
+    pub const fn set_forecast_curve_id(mut self, forecast_curve_id: usize) -> Self {
         self.forecast_curve_id = Some(forecast_curve_id);
         self
     }

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -101,6 +101,7 @@ impl HasCashflows for Instrument {
 
 impl Instrument {
     /// Returns the notional value of the instrument.
+    #[must_use]
     pub fn notional(&self) -> f64 {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.notional(),
@@ -111,6 +112,7 @@ impl Instrument {
     }
 
     /// Returns the start date of the instrument.
+    #[must_use]
     pub fn start_date(&self) -> Date {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.start_date(),
@@ -121,6 +123,7 @@ impl Instrument {
     }
 
     /// Returns the end date of the instrument.
+    #[must_use]
     pub fn end_date(&self) -> Date {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.end_date(),
@@ -131,6 +134,7 @@ impl Instrument {
     }
 
     /// Returns the identifier of the instrument.
+    #[must_use]
     pub fn id(&self) -> Option<String> {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.id(),
@@ -141,6 +145,7 @@ impl Instrument {
     }
 
     /// Returns the structure of the instrument.
+    #[must_use]
     pub fn structure(&self) -> Structure {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.structure(),
@@ -151,6 +156,7 @@ impl Instrument {
     }
 
     /// Returns the payment frequency of the instrument.
+    #[must_use]
     pub fn payment_frequency(&self) -> Frequency {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.payment_frequency(),
@@ -161,6 +167,7 @@ impl Instrument {
     }
 
     /// Returns the side of the instrument.
+    #[must_use]
     pub fn side(&self) -> Option<Side> {
         match self {
             Instrument::FixedRateInstrument(fri) => Some(fri.side()),
@@ -171,6 +178,7 @@ impl Instrument {
     }
 
     /// Returns the issue date of the instrument.
+    #[must_use]
     pub fn issue_date(&self) -> Option<Date> {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.issue_date(),
@@ -181,6 +189,7 @@ impl Instrument {
     }
 
     /// Returns the rate type of the instrument.
+    #[must_use]
     pub fn rate_type(&self) -> RateType {
         match self {
             Instrument::FixedRateInstrument(_) => RateType::Fixed,
@@ -191,6 +200,7 @@ impl Instrument {
     }
 
     /// Returns the fixed rate of the instrument, if applicable.
+    #[must_use]
     pub fn rate(&self) -> Option<f64> {
         match self {
             Instrument::FixedRateInstrument(fri) => Some(fri.rate().rate()),
@@ -201,6 +211,7 @@ impl Instrument {
     }
 
     /// Returns the spread of the instrument, if applicable.
+    #[must_use]
     pub fn spread(&self) -> Option<f64> {
         match self {
             Instrument::FixedRateInstrument(_) => None,
@@ -211,6 +222,7 @@ impl Instrument {
     }
 
     /// Returns the forecast curve identifier of the instrument.
+    #[must_use]
     pub fn forecast_curve_id(&self) -> Option<usize> {
         match self {
             Instrument::FixedRateInstrument(_) => None,
@@ -221,6 +233,7 @@ impl Instrument {
     }
 
     /// Returns the discount curve identifier of the instrument.
+    #[must_use]
     pub fn discount_curve_id(&self) -> Option<usize> {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.discount_curve_id(),
@@ -251,6 +264,7 @@ impl Instrument {
     }
 
     /// Returns the first rate definition of the instrument.
+    #[must_use]
     pub fn first_rate_definition(&self) -> Option<RateDefinition> {
         match self {
             Instrument::FixedRateInstrument(fri) => Some(fri.rate().rate_definition()),
@@ -261,6 +275,7 @@ impl Instrument {
     }
 
     /// Returns the second rate definition of the instrument.
+    #[must_use]
     pub fn second_rate_definition(&self) -> Option<RateDefinition> {
         match self {
             Instrument::FixedRateInstrument(_) => None,

--- a/src/instruments/leg.rs
+++ b/src/instruments/leg.rs
@@ -23,7 +23,8 @@ pub struct Leg {
 
 impl Leg {
     /// Creates a new `Leg` with the specified parameters.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         structure: Structure,
         rate_type: RateType,
         rate_value: f64,
@@ -48,47 +49,56 @@ impl Leg {
     }
 
     /// Returns a slice of the cashflows in this leg.
+    #[must_use]
     pub fn cashflows(&self) -> &[Cashflow] {
         &self.cashflows
     }
 
     /// Returns the structure of this leg.
-    pub fn structure(&self) -> Structure {
+    #[must_use]
+    pub const fn structure(&self) -> Structure {
         self.structure
     }
 
     /// Returns the rate type of this leg.
-    pub fn rate_type(&self) -> RateType {
+    #[must_use]
+    pub const fn rate_type(&self) -> RateType {
         self.rate_type
     }
 
     /// Returns the rate value of this leg.
-    pub fn rate_value(&self) -> f64 {
+    #[must_use]
+    pub const fn rate_value(&self) -> f64 {
         self.rate_value
     }
 
     /// Returns the rate definition of this leg.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Returns the currency of this leg.
-    pub fn currency(&self) -> Currency {
+    #[must_use]
+    pub const fn currency(&self) -> Currency {
         self.currency
     }
 
     /// Returns the side of this leg.
-    pub fn side(&self) -> Side {
+    #[must_use]
+    pub const fn side(&self) -> Side {
         self.side
     }
 
     /// Returns the discount curve ID of this leg, if set.
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         self.discount_curve_id
     }
 
     /// Returns the forecast curve ID of this leg, if set.
-    pub fn forecast_curve_id(&self) -> Option<usize> {
+    #[must_use]
+    pub const fn forecast_curve_id(&self) -> Option<usize> {
         self.forecast_curve_id
     }
 

--- a/src/instruments/makedoublerateinstrument.rs
+++ b/src/instruments/makedoublerateinstrument.rs
@@ -59,7 +59,8 @@ pub struct MakeDoubleRateInstrument {
 
 impl MakeDoubleRateInstrument {
     /// Creates a new instance of MakeDoubleRateInstrument with default values.
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         MakeDoubleRateInstrument {
             start_date: None,
             end_date: None,
@@ -88,79 +89,92 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the issue date.
-    pub fn with_issue_date(mut self, issue_date: Date) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeDoubleRateInstrument {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
-    pub fn with_first_coupon_date(mut self, first_coupon_date: Date) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_first_coupon_date(mut self, first_coupon_date: Date) -> MakeDoubleRateInstrument {
         self.first_coupon_date = Some(first_coupon_date);
         self
     }
 
     /// Sets the currency.
-    pub fn with_currency(mut self, currency: Currency) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> MakeDoubleRateInstrument {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
-    pub fn with_side(mut self, side: Side) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_side(mut self, side: Side) -> MakeDoubleRateInstrument {
         self.side = Some(side);
         self
     }
 
     /// Sets the notional.
-    pub fn with_notional(mut self, notional: f64) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> MakeDoubleRateInstrument {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the instrument identifier.
+    #[must_use]
     pub fn with_id(mut self, id: String) -> MakeDoubleRateInstrument {
         self.id = Some(id);
         self
     }
 
     /// Sets the start date.
-    pub fn with_start_date(mut self, start_date: Date) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> MakeDoubleRateInstrument {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
-    pub fn with_end_date(mut self, end_date: Date) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> MakeDoubleRateInstrument {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the discount curve id.
-    pub fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the forecast curve id.
-    pub fn with_forecast_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_forecast_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
         self.forecast_curve_id = id;
         self
     }
 
     /// Sets the tenor.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeDoubleRateInstrument {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the change rate date.
-    pub fn with_tenor_change_rate(mut self, tenor_change_rate: Period) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_tenor_change_rate(mut self, tenor_change_rate: Period) -> MakeDoubleRateInstrument {
         self.tenor_change_rate = Some(tenor_change_rate);
         self
     }
 
     /// Sets the tenor grace period.
-    pub fn with_tenor_grace_period(
+    #[must_use]
+    pub const fn with_tenor_grace_period(
         mut self,
         tenor_grace_period: Period,
     ) -> MakeDoubleRateInstrument {
@@ -169,19 +183,22 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the payment frequency.
-    pub fn with_payment_frequency(mut self, frequency: Frequency) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeDoubleRateInstrument {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the change rate date.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Calendar) -> MakeDoubleRateInstrument {
         self.calendar = Some(calendar);
         self
     }
 
     /// Sets the business day convention.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         business_day_convention: BusinessDayConvention,
     ) -> MakeDoubleRateInstrument {
@@ -190,7 +207,8 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the date generation rule.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: DateGenerationRule,
     ) -> MakeDoubleRateInstrument {
@@ -199,13 +217,15 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the rate type.
-    pub fn with_rate_type(mut self, rate_type: RateType) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_rate_type(mut self, rate_type: RateType) -> MakeDoubleRateInstrument {
         self.rate_type = Some(rate_type);
         self
     }
 
     /// Sets the rate definition for the first part.
-    pub fn with_first_part_rate_definition(
+    #[must_use]
+    pub const fn with_first_part_rate_definition(
         mut self,
         rate_definition: RateDefinition,
     ) -> MakeDoubleRateInstrument {
@@ -214,13 +234,15 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the rate value for the first part.
-    pub fn with_first_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_first_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
         self.first_part_rate = Some(rate);
         self
     }
 
     /// Sets the rate definition for the second part.
-    pub fn with_second_part_rate_definition(
+    #[must_use]
+    pub const fn with_second_part_rate_definition(
         mut self,
         rate_definition: RateDefinition,
     ) -> MakeDoubleRateInstrument {
@@ -229,7 +251,8 @@ impl MakeDoubleRateInstrument {
     }
 
     /// Sets the rate value for the second part.
-    pub fn with_second_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
+    #[must_use]
+    pub const fn with_second_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
         self.second_part_rate = Some(rate);
         self
     }

--- a/src/instruments/makefixedrateinstrument.rs
+++ b/src/instruments/makefixedrateinstrument.rs
@@ -64,7 +64,8 @@ pub struct MakeFixedRateInstrument {
 /// New, setters and getters
 impl MakeFixedRateInstrument {
     /// Creates a new MakeFixedRateInstrument builder with default values.
-    pub fn new() -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn new() -> MakeFixedRateInstrument {
         MakeFixedRateInstrument {
             start_date: None,
             end_date: None,
@@ -92,13 +93,15 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the issue date.
-    pub fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateInstrument {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
-    pub fn with_first_coupon_date(
+    #[must_use]
+    pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
     ) -> MakeFixedRateInstrument {
@@ -107,13 +110,15 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the currency.
-    pub fn with_currency(mut self, currency: Currency) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> MakeFixedRateInstrument {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
-    pub fn with_side(mut self, side: Side) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_side(mut self, side: Side) -> MakeFixedRateInstrument {
         self.side = Some(side);
         self
     }
@@ -122,31 +127,36 @@ impl MakeFixedRateInstrument {
     ///
     /// ### Details
     /// Currently does not handle negative amounts.
-    pub fn with_notional(mut self, notional: f64) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> MakeFixedRateInstrument {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the instrument id.
+    #[must_use]
     pub fn with_id(mut self, id: Option<String>) -> MakeFixedRateInstrument {
         self.id = id;
         self
     }
 
     /// Sets the yield rate.
-    pub fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateInstrument {
         self.yield_rate = Some(yield_rate);
         self
     }
 
     /// Sets the calendar.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFixedRateInstrument {
         self.calendar = calendar;
         self
     }
 
     /// Sets the business day convention.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
     ) -> MakeFixedRateInstrument {
@@ -155,7 +165,8 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the date generation rule.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> MakeFixedRateInstrument {
@@ -164,6 +175,7 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the rate definition.
+    #[must_use]
     pub fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
@@ -193,6 +205,7 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the rate value.
+    #[must_use]
     pub fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateInstrument {
         self.rate_value = Some(rate_value);
         match self.rate {
@@ -219,18 +232,21 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the start date.
-    pub fn with_start_date(mut self, start_date: Date) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> MakeFixedRateInstrument {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
-    pub fn with_end_date(mut self, end_date: Date) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> MakeFixedRateInstrument {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the disbursements.
+    #[must_use]
     pub fn with_disbursements(
         mut self,
         disbursements: HashMap<Date, f64>,
@@ -240,12 +256,14 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the redemptions.
+    #[must_use]
     pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFixedRateInstrument {
         self.redemptions = Some(redemptions);
         self
     }
 
     /// Sets the additional coupon dates.
+    #[must_use]
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
@@ -255,63 +273,73 @@ impl MakeFixedRateInstrument {
     }
 
     /// Sets the rate.
-    pub fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateInstrument {
         self.rate = Some(rate);
         self
     }
 
     /// Sets the discount curve id.
-    pub fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateInstrument {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the tenor.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeFixedRateInstrument {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the payment frequency.
-    pub fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateInstrument {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure to bullet.
-    pub fn bullet(mut self) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn bullet(mut self) -> MakeFixedRateInstrument {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
-    pub fn equal_redemptions(mut self) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn equal_redemptions(mut self) -> MakeFixedRateInstrument {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
-    pub fn zero(mut self) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn zero(mut self) -> MakeFixedRateInstrument {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
     }
 
     /// Sets the structure to equal payments.
-    pub fn equal_payments(mut self) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn equal_payments(mut self) -> MakeFixedRateInstrument {
         self.structure = Some(Structure::EqualPayments);
         self
     }
 
     /// Sets the structure to other.
-    pub fn other(mut self) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn other(mut self) -> MakeFixedRateInstrument {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
     }
 
     /// Sets the structure.
-    pub fn with_structure(mut self, structure: Structure) -> MakeFixedRateInstrument {
+    #[must_use]
+    pub const fn with_structure(mut self, structure: Structure) -> MakeFixedRateInstrument {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makefixedrateleg.rs
+++ b/src/instruments/makefixedrateleg.rs
@@ -62,7 +62,8 @@ pub struct MakeFixedRateLeg {
 /// New, setters and getters
 impl MakeFixedRateLeg {
     /// Creates a new MakeFixedRateLeg builder with default values.
-    pub fn new() -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn new() -> MakeFixedRateLeg {
         MakeFixedRateLeg {
             start_date: None,
             end_date: None,
@@ -90,31 +91,36 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the end of month flag.
-    pub fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFixedRateLeg {
         self.end_of_month = end_of_month;
         self
     }
 
     /// Sets the issue date.
-    pub fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateLeg {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
-    pub fn with_first_coupon_date(mut self, first_coupon_date: Option<Date>) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_first_coupon_date(mut self, first_coupon_date: Option<Date>) -> MakeFixedRateLeg {
         self.first_coupon_date = first_coupon_date;
         self
     }
 
     /// Sets the currency.
-    pub fn with_currency(mut self, currency: Currency) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> MakeFixedRateLeg {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
-    pub fn with_side(mut self, side: Side) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_side(mut self, side: Side) -> MakeFixedRateLeg {
         self.side = Some(side);
         self
     }
@@ -123,25 +129,29 @@ impl MakeFixedRateLeg {
     ///
     /// ### Details
     /// Currently does not handle negative amounts.
-    pub fn with_notional(mut self, notional: f64) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> MakeFixedRateLeg {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the yield rate.
-    pub fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateLeg {
         self.yield_rate = Some(yield_rate);
         self
     }
 
     /// Sets the calendar.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFixedRateLeg {
         self.calendar = calendar;
         self
     }
 
     /// Sets the business day convention.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
     ) -> MakeFixedRateLeg {
@@ -150,7 +160,8 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the date generation rule.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> MakeFixedRateLeg {
@@ -159,6 +170,7 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the rate definition.
+    #[must_use]
     pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> MakeFixedRateLeg {
         self.rate_definition = Some(rate_definition);
         match self.rate_value {
@@ -185,6 +197,7 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the rate value.
+    #[must_use]
     pub fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateLeg {
         self.rate_value = Some(rate_value);
         match self.rate {
@@ -211,30 +224,35 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the start date.
-    pub fn with_start_date(mut self, start_date: Date) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> MakeFixedRateLeg {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
-    pub fn with_end_date(mut self, end_date: Date) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> MakeFixedRateLeg {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the disbursements.
+    #[must_use]
     pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> MakeFixedRateLeg {
         self.disbursements = Some(disbursements);
         self
     }
 
     /// Sets the redemptions.
+    #[must_use]
     pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFixedRateLeg {
         self.redemptions = Some(redemptions);
         self
     }
 
     /// Sets the additional coupon dates.
+    #[must_use]
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
@@ -244,63 +262,73 @@ impl MakeFixedRateLeg {
     }
 
     /// Sets the rate.
-    pub fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateLeg {
         self.rate = Some(rate);
         self
     }
 
     /// Sets the discount curve id.
-    pub fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateLeg {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the tenor.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeFixedRateLeg {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the payment frequency.
-    pub fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateLeg {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure to bullet.
-    pub fn bullet(mut self) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn bullet(mut self) -> MakeFixedRateLeg {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
-    pub fn equal_redemptions(mut self) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn equal_redemptions(mut self) -> MakeFixedRateLeg {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
-    pub fn zero(mut self) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn zero(mut self) -> MakeFixedRateLeg {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
     }
 
     /// Sets the structure to equal payments.
-    pub fn equal_payments(mut self) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn equal_payments(mut self) -> MakeFixedRateLeg {
         self.structure = Some(Structure::EqualPayments);
         self
     }
 
     /// Sets the structure to other.
-    pub fn other(mut self) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn other(mut self) -> MakeFixedRateLeg {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
     }
 
     /// Sets the structure.
-    pub fn with_structure(mut self, structure: Structure) -> MakeFixedRateLeg {
+    #[must_use]
+    pub const fn with_structure(mut self, structure: Structure) -> MakeFixedRateLeg {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makefloatingrateinstrument.rs
+++ b/src/instruments/makefloatingrateinstrument.rs
@@ -57,7 +57,8 @@ pub struct MakeFloatingRateInstrument {
 /// Constructor, setters and getters.
 impl MakeFloatingRateInstrument {
     /// Creates a new `MakeFloatingRateInstrument` with all fields initialized to `None`.
-    pub fn new() -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn new() -> MakeFloatingRateInstrument {
         MakeFloatingRateInstrument {
             start_date: None,
             end_date: None,
@@ -84,13 +85,15 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the calendar for the instrument.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFloatingRateInstrument {
         self.calendar = calendar;
         self
     }
 
     /// Sets the business day convention for the instrument.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
     ) -> MakeFloatingRateInstrument {
@@ -99,7 +102,8 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the date generation rule for the instrument.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> MakeFloatingRateInstrument {
@@ -108,19 +112,22 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the issue date for the instrument.
-    pub fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateInstrument {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the identifier for the instrument.
+    #[must_use]
     pub fn with_id(mut self, id: Option<String>) -> MakeFloatingRateInstrument {
         self.id = id;
         self
     }
 
     /// Sets the first coupon date for the instrument.
-    pub fn with_first_coupon_date(
+    #[must_use]
+    pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
     ) -> MakeFloatingRateInstrument {
@@ -129,24 +136,28 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the start date for the instrument.
-    pub fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateInstrument {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date for the instrument.
-    pub fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateInstrument {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the tenor for the instrument.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateInstrument {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the disbursements schedule for the instrument.
+    #[must_use]
     pub fn with_disbursements(
         mut self,
         disbursements: HashMap<Date, f64>,
@@ -156,6 +167,7 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the redemptions schedule for the instrument.
+    #[must_use]
     pub fn with_redemptions(
         mut self,
         redemptions: HashMap<Date, f64>,
@@ -165,6 +177,7 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the additional coupon dates for the instrument.
+    #[must_use]
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
@@ -174,7 +187,8 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the forecast curve identifier for the instrument.
-    pub fn with_forecast_curve_id(
+    #[must_use]
+    pub const fn with_forecast_curve_id(
         mut self,
         forecast_curve_id: Option<usize>,
     ) -> MakeFloatingRateInstrument {
@@ -183,7 +197,8 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the discount curve identifier for the instrument.
-    pub fn with_discount_curve_id(
+    #[must_use]
+    pub const fn with_discount_curve_id(
         mut self,
         discount_curve_id: Option<usize>,
     ) -> MakeFloatingRateInstrument {
@@ -192,7 +207,8 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the rate definition for the instrument.
-    pub fn with_rate_definition(
+    #[must_use]
+    pub const fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
     ) -> MakeFloatingRateInstrument {
@@ -201,63 +217,73 @@ impl MakeFloatingRateInstrument {
     }
 
     /// Sets the notional amount for the instrument.
-    pub fn with_notional(mut self, notional: f64) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> MakeFloatingRateInstrument {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the currency for the instrument.
-    pub fn with_currency(mut self, currency: Currency) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> MakeFloatingRateInstrument {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the spread for the floating rate instrument.
-    pub fn with_spread(mut self, spread: f64) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_spread(mut self, spread: f64) -> MakeFloatingRateInstrument {
         self.spread = Some(spread);
         self
     }
 
     /// Sets the instrument structure to bullet.
-    pub fn bullet(mut self) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn bullet(mut self) -> MakeFloatingRateInstrument {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the instrument structure to equal redemptions.
-    pub fn equal_redemptions(mut self) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn equal_redemptions(mut self) -> MakeFloatingRateInstrument {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the instrument structure to zero with single payment frequency.
-    pub fn zero(mut self) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn zero(mut self) -> MakeFloatingRateInstrument {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
     }
 
     /// Sets the instrument structure to other with custom frequency.
-    pub fn other(mut self) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn other(mut self) -> MakeFloatingRateInstrument {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
     }
 
     /// Sets the side (Receive or Pay) for the instrument.
-    pub fn with_side(mut self, side: Side) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_side(mut self, side: Side) -> MakeFloatingRateInstrument {
         self.side = Some(side);
         self
     }
 
     /// Sets the payment frequency for the instrument.
-    pub fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateInstrument {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure for the instrument.
-    pub fn with_structure(mut self, structure: Structure) -> MakeFloatingRateInstrument {
+    #[must_use]
+    pub const fn with_structure(mut self, structure: Structure) -> MakeFloatingRateInstrument {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makefloatingrateleg.rs
+++ b/src/instruments/makefloatingrateleg.rs
@@ -55,7 +55,8 @@ pub struct MakeFloatingRateLeg {
 /// Constructor, setters and getters.
 impl MakeFloatingRateLeg {
     /// Creates a new `MakeFloatingRateLeg` builder with default values.
-    pub fn new() -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn new() -> MakeFloatingRateLeg {
         MakeFloatingRateLeg {
             start_date: None,
             end_date: None,
@@ -82,19 +83,22 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the end of month flag.
-    pub fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFloatingRateLeg {
         self.end_of_month = end_of_month;
         self
     }
 
     /// Sets the calendar for business day adjustments.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFloatingRateLeg {
         self.calendar = calendar;
         self
     }
 
     /// Sets the business day convention.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
     ) -> MakeFloatingRateLeg {
@@ -103,7 +107,8 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the date generation rule.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> MakeFloatingRateLeg {
@@ -112,13 +117,15 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the issue date.
-    pub fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateLeg {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
-    pub fn with_first_coupon_date(
+    #[must_use]
+    pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
     ) -> MakeFloatingRateLeg {
@@ -127,36 +134,42 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the start date.
-    pub fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateLeg {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
-    pub fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateLeg {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the tenor.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateLeg {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the disbursement schedule.
+    #[must_use]
     pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> MakeFloatingRateLeg {
         self.disbursements = Some(disbursements);
         self
     }
 
     /// Sets the redemption schedule.
+    #[must_use]
     pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFloatingRateLeg {
         self.redemptions = Some(redemptions);
         self
     }
 
     /// Sets additional coupon dates.
+    #[must_use]
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
@@ -166,7 +179,8 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the forecast curve ID.
-    pub fn with_forecast_curve_id(
+    #[must_use]
+    pub const fn with_forecast_curve_id(
         mut self,
         forecast_curve_id: Option<usize>,
     ) -> MakeFloatingRateLeg {
@@ -175,7 +189,8 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the discount curve ID.
-    pub fn with_discount_curve_id(
+    #[must_use]
+    pub const fn with_discount_curve_id(
         mut self,
         discount_curve_id: Option<usize>,
     ) -> MakeFloatingRateLeg {
@@ -184,69 +199,80 @@ impl MakeFloatingRateLeg {
     }
 
     /// Sets the rate definition.
-    pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> MakeFloatingRateLeg {
         self.rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the notional amount.
-    pub fn with_notional(mut self, notional: f64) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> MakeFloatingRateLeg {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the currency.
-    pub fn with_currency(mut self, currency: Currency) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> MakeFloatingRateLeg {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the spread.
-    pub fn with_spread(mut self, spread: f64) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_spread(mut self, spread: f64) -> MakeFloatingRateLeg {
         self.spread = Some(spread);
         self
     }
 
     /// Sets the structure to bullet.
-    pub fn bullet(mut self) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn bullet(mut self) -> MakeFloatingRateLeg {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
-    pub fn equal_redemptions(mut self) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn equal_redemptions(mut self) -> MakeFloatingRateLeg {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
-    pub fn zero(mut self) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn zero(mut self) -> MakeFloatingRateLeg {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
     }
 
     /// Sets the structure to other.
-    pub fn other(mut self) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn other(mut self) -> MakeFloatingRateLeg {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
     }
 
     /// Sets the side of the transaction.
-    pub fn with_side(mut self, side: Side) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_side(mut self, side: Side) -> MakeFloatingRateLeg {
         self.side = Some(side);
         self
     }
 
     /// Sets the payment frequency.
-    pub fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateLeg {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure.
-    pub fn with_structure(mut self, structure: Structure) -> MakeFloatingRateLeg {
+    #[must_use]
+    pub const fn with_structure(mut self, structure: Structure) -> MakeFloatingRateLeg {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makeswap.rs
+++ b/src/instruments/makeswap.rs
@@ -64,7 +64,8 @@ pub struct MakeSwap {
 
 impl MakeSwap {
     /// Creates a new MakeSwap builder with default values.
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         MakeSwap {
             first_leg_rate_type: None,
             first_leg_rate_value: None,
@@ -111,7 +112,8 @@ impl MakeSwap {
     }
 
     /// Sets the date generation rule for the first leg.
-    pub fn with_first_leg_date_generation_rule(
+    #[must_use]
+    pub const fn with_first_leg_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> Self {
@@ -120,7 +122,8 @@ impl MakeSwap {
     }
 
     /// Sets the date generation rule for the second leg.
-    pub fn with_second_leg_date_generation_rule(
+    #[must_use]
+    pub const fn with_second_leg_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> Self {
@@ -129,49 +132,57 @@ impl MakeSwap {
     }
 
     /// Sets the notional for the first leg.
-    pub fn with_first_leg_notional(mut self, notional: f64) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_notional(mut self, notional: f64) -> Self {
         self.first_leg_notional = Some(notional);
         self
     }
 
     /// Sets the notional for the second leg.
-    pub fn with_second_leg_notional(mut self, notional: f64) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_notional(mut self, notional: f64) -> Self {
         self.second_leg_notional = Some(notional);
         self
     }
 
     /// Sets the start date for the first leg.
-    pub fn with_first_leg_start_date(mut self, start_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_start_date(mut self, start_date: Date) -> Self {
         self.first_leg_start_date = Some(start_date);
         self
     }
 
     /// Sets the end date for the first leg.
-    pub fn with_first_leg_end_date(mut self, end_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_end_date(mut self, end_date: Date) -> Self {
         self.first_leg_end_date = Some(end_date);
         self
     }
 
     /// Sets the start date for the second leg.
-    pub fn with_second_leg_start_date(mut self, start_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_start_date(mut self, start_date: Date) -> Self {
         self.second_leg_start_date = Some(start_date);
         self
     }
 
     /// Sets the end date for the second leg.
-    pub fn with_second_leg_end_date(mut self, end_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_end_date(mut self, end_date: Date) -> Self {
         self.second_leg_end_date = Some(end_date);
         self
     }
 
     /// Sets the calendar for the first leg.
+    #[must_use]
     pub fn with_first_leg_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.first_leg_calendar = calendar;
         self
     }
 
     /// Sets the business day convention for the first leg.
-    pub fn with_first_leg_business_day_convention(
+    #[must_use]
+    pub const fn with_first_leg_business_day_convention(
         mut self,
         convention: Option<BusinessDayConvention>,
     ) -> Self {
@@ -180,19 +191,22 @@ impl MakeSwap {
     }
 
     /// Sets the end of month flag for the first leg.
-    pub fn with_first_leg_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
         self.first_leg_end_of_month = end_of_month;
         self
     }
 
     /// Sets the calendar for the second leg.
+    #[must_use]
     pub fn with_second_leg_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.second_leg_calendar = calendar;
         self
     }
 
     /// Sets the business day convention for the second leg.
-    pub fn with_second_leg_business_day_convention(
+    #[must_use]
+    pub const fn with_second_leg_business_day_convention(
         mut self,
         convention: Option<BusinessDayConvention>,
     ) -> Self {
@@ -201,157 +215,183 @@ impl MakeSwap {
     }
 
     /// Sets the end of month flag for the second leg.
-    pub fn with_second_leg_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
         self.second_leg_end_of_month = end_of_month;
         self
     }
 
     /// Sets additional coupon dates for the second leg.
+    #[must_use]
     pub fn with_second_leg_additional_coupon_dates(mut self, dates: HashSet<Date>) -> Self {
         self.second_leg_additional_coupon_dates = Some(dates);
         self
     }
 
     /// Sets disbursements for the first leg.
+    #[must_use]
     pub fn with_first_leg_disbursements(mut self, disbursements: HashMap<Date, f64>) -> Self {
         self.first_leg_disbursements = Some(disbursements);
         self
     }
 
     /// Sets redemptions for the first leg.
+    #[must_use]
     pub fn with_first_leg_redemptions(mut self, redemptions: HashMap<Date, f64>) -> Self {
         self.first_leg_redemptions = Some(redemptions);
         self
     }
 
     /// Sets additional coupon dates for the first leg.
+    #[must_use]
     pub fn with_first_leg_additional_coupon_dates(mut self, dates: HashSet<Date>) -> Self {
         self.first_leg_additional_coupon_dates = Some(dates);
         self
     }
 
     /// Sets disbursements for the second leg.
+    #[must_use]
     pub fn with_second_leg_disbursements(mut self, disbursements: HashMap<Date, f64>) -> Self {
         self.second_leg_disbursements = Some(disbursements);
         self
     }
 
     /// Sets redemptions for the second leg.
+    #[must_use]
     pub fn with_second_leg_redemptions(mut self, redemptions: HashMap<Date, f64>) -> Self {
         self.second_leg_redemptions = Some(redemptions);
         self
     }
 
     /// Sets the rate type for the first leg.
-    pub fn with_first_leg_rate_type(mut self, rate_type: RateType) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_rate_type(mut self, rate_type: RateType) -> Self {
         self.first_leg_rate_type = Some(rate_type);
         self
     }
 
     /// Sets the rate value for the first leg.
-    pub fn with_first_leg_rate_value(mut self, rate_value: f64) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_rate_value(mut self, rate_value: f64) -> Self {
         self.first_leg_rate_value = Some(rate_value);
         self
     }
 
     /// Sets the payment frequency for the first leg.
-    pub fn with_first_leg_payment_frequency(mut self, frequency: Frequency) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.first_leg_payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the rate definition for the first leg.
-    pub fn with_first_leg_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.first_leg_rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the currency for the first leg.
-    pub fn with_first_leg_currency(mut self, currency: Currency) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_currency(mut self, currency: Currency) -> Self {
         self.first_leg_currency = Some(currency);
         self
     }
 
     /// Sets the side for the first leg.
-    pub fn with_first_leg_side(mut self, side: Side) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_side(mut self, side: Side) -> Self {
         self.first_leg_side = Some(side);
         self
     }
 
     /// Sets the discount curve ID for the first leg.
-    pub fn with_first_leg_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.first_leg_discount_curve_id = curve_id;
         self
     }
 
     /// Sets the forecast curve ID for the first leg.
-    pub fn with_first_leg_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.first_leg_forecast_curve_id = curve_id;
         self
     }
 
     /// Sets the rate type for the second leg.
-    pub fn with_second_leg_rate_type(mut self, rate_type: RateType) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_rate_type(mut self, rate_type: RateType) -> Self {
         self.second_leg_rate_type = Some(rate_type);
         self
     }
 
     /// Sets the rate value for the second leg.
-    pub fn with_second_leg_rate_value(mut self, rate_value: f64) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_rate_value(mut self, rate_value: f64) -> Self {
         self.second_leg_rate_value = Some(rate_value);
         self
     }
 
     /// Sets the rate definition for the second leg.
-    pub fn with_second_leg_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.second_leg_rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the currency for the second leg.
-    pub fn with_second_leg_currency(mut self, currency: Currency) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_currency(mut self, currency: Currency) -> Self {
         self.second_leg_currency = Some(currency);
         self
     }
 
     /// Sets the side for the second leg.
-    pub fn with_second_leg_side(mut self, side: Side) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_side(mut self, side: Side) -> Self {
         self.second_leg_side = Some(side);
         self
     }
 
     /// Sets the discount curve ID for the second leg.
-    pub fn with_second_leg_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.second_leg_discount_curve_id = curve_id;
         self
     }
 
     /// Sets the forecast curve ID for the second leg.
-    pub fn with_second_leg_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.second_leg_forecast_curve_id = curve_id;
         self
     }
 
     /// Sets the identifier for the instrument.
+    #[must_use]
     pub fn with_id(mut self, id: String) -> Self {
         self.id = Some(id);
         self
     }
 
     /// Sets the structure for the first leg.
-    pub fn with_first_leg_structure(mut self, structure: Structure) -> Self {
+    #[must_use]
+    pub const fn with_first_leg_structure(mut self, structure: Structure) -> Self {
         self.first_leg_structure = Some(structure);
         self
     }
 
     /// Sets the structure for the second leg.
-    pub fn with_second_leg_structure(mut self, structure: Structure) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_structure(mut self, structure: Structure) -> Self {
         self.second_leg_structure = Some(structure);
         self
     }
 
     /// Sets the payment frequency for the second leg.
-    pub fn with_second_leg_payment_frequency(mut self, frequency: Frequency) -> Self {
+    #[must_use]
+    pub const fn with_second_leg_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.second_leg_payment_frequency = Some(frequency);
         self
     }
@@ -759,7 +799,8 @@ pub struct MakeFixFloatSwap {
 
 impl MakeFixFloatSwap {
     /// Creates a new MakeFixFloatSwap builder with default values.
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         MakeFixFloatSwap {
             rate_value: None,
             rate_definition: None,
@@ -778,67 +819,78 @@ impl MakeFixFloatSwap {
     }
 
     /// Sets the fixed rate value.
-    pub fn with_rate_value(mut self, rate_value: f64) -> Self {
+    #[must_use]
+    pub const fn with_rate_value(mut self, rate_value: f64) -> Self {
         self.rate_value = Some(rate_value);
         self
     }
 
     /// Sets the rate definition.
-    pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
+    #[must_use]
+    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the currency.
-    pub fn with_currency(mut self, currency: Currency) -> Self {
+    #[must_use]
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side for the fixed leg.
-    pub fn with_fix_leg_side(mut self, side: Side) -> Self {
+    #[must_use]
+    pub const fn with_fix_leg_side(mut self, side: Side) -> Self {
         self.fix_leg_side = Some(side);
         self
     }
 
     /// Sets the discount curve ID.
-    pub fn with_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_discount_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.discount_curve_id = curve_id;
         self
     }
 
     /// Sets the forecast curve ID.
-    pub fn with_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
+    #[must_use]
+    pub const fn with_forecast_curve_id(mut self, curve_id: Option<usize>) -> Self {
         self.forecast_curve_id = curve_id;
         self
     }
 
     /// Sets the notional amount.
-    pub fn with_notional(mut self, notional: f64) -> Self {
+    #[must_use]
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the start date.
-    pub fn with_start_date(mut self, start_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
-    pub fn with_end_date(mut self, end_date: Date) -> Self {
+    #[must_use]
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the calendar.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.calendar = calendar;
         self
     }
 
     /// Sets the business day convention.
-    pub fn with_business_day_convention(
+    #[must_use]
+    pub const fn with_business_day_convention(
         mut self,
         convention: Option<BusinessDayConvention>,
     ) -> Self {
@@ -847,7 +899,8 @@ impl MakeFixFloatSwap {
     }
 
     /// Sets the date generation rule.
-    pub fn with_date_generation_rule(
+    #[must_use]
+    pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
     ) -> Self {
@@ -856,6 +909,7 @@ impl MakeFixFloatSwap {
     }
 
     /// Sets the identifier.
+    #[must_use]
     pub fn with_id(mut self, id: String) -> Self {
         self.id = Some(id);
         self

--- a/src/instruments/swap.rs
+++ b/src/instruments/swap.rs
@@ -11,7 +11,8 @@ pub struct Swap {
 
 impl Swap {
     /// Create a new swap.
-    pub fn new(cashflows: Vec<Cashflow>, legs: Vec<Leg>, id: Option<String>) -> Self {
+    #[must_use]
+    pub const fn new(cashflows: Vec<Cashflow>, legs: Vec<Leg>, id: Option<String>) -> Self {
         Swap {
             cashflows,
             legs,
@@ -27,17 +28,20 @@ impl Swap {
     }
 
     /// Get the legs of the swap.
-    pub fn legs(&self) -> &Vec<Leg> {
+    #[must_use]
+    pub const fn legs(&self) -> &Vec<Leg> {
         &self.legs
     }
 
     /// Get the cashflows of the swap.
-    pub fn cashflows(&self) -> &Vec<Cashflow> {
+    #[must_use]
+    pub const fn cashflows(&self) -> &Vec<Cashflow> {
         &self.cashflows
     }
 
     /// Get the id of the swap.
-    pub fn id(&self) -> &Option<String> {
+    #[must_use]
+    pub const fn id(&self) -> &Option<String> {
         &self.id
     }
 

--- a/src/instruments/traits.rs
+++ b/src/instruments/traits.rs
@@ -85,6 +85,7 @@ impl From<CashflowType> for String {
 }
 
 /// Infer cashflows from amounts to handle negative amounts and sides.
+#[must_use]
 pub fn infer_cashflows_from_amounts(
     dates: &[Date],
     amounts: &[f64],
@@ -131,6 +132,7 @@ pub fn add_cashflows_to_vec(
 }
 
 /// Calculate the notionals for a given structure
+#[must_use]
 pub fn notionals_vector(n: usize, notional: f64, structure: Structure) -> Vec<f64> {
     match structure {
         Structure::Bullet => vec![notional; n],
@@ -150,6 +152,7 @@ pub fn notionals_vector(n: usize, notional: f64, structure: Structure) -> Vec<f6
 }
 
 /// Calculate the outstanding amounts for a given set of disbursements and redemptions
+#[must_use]
 pub fn calculate_outstanding(
     disbursements: &HashMap<Date, f64>,
     redemptions: &HashMap<Date, f64>,

--- a/src/math/interpolation/enums.rs
+++ b/src/math/interpolation/enums.rs
@@ -25,6 +25,7 @@ pub enum Interpolator {
 
 impl Interpolator {
     /// Performs interpolation for a given x value using the specified interpolation method.
+    #[must_use]
     pub fn interpolate(&self, x: f64, x_: &[f64], y_: &[f64], enable_extrapolation: bool) -> f64 {
         match self {
             Interpolator::Linear => {

--- a/src/models/simplemodel.rs
+++ b/src/models/simplemodel.rs
@@ -32,7 +32,8 @@ impl<'a> SimpleModel<'a> {
     ///
     /// # Returns
     /// A new `SimpleModel` instance with currency transformation disabled by default.
-    pub fn new(market_store: &'a MarketStore) -> SimpleModel<'a> {
+    #[must_use]
+    pub const fn new(market_store: &'a MarketStore) -> SimpleModel<'a> {
         SimpleModel {
             market_store,
             transform_currencies: false,
@@ -46,7 +47,8 @@ impl<'a> SimpleModel<'a> {
     ///
     /// # Returns
     /// The modified `SimpleModel` instance for method chaining.
-    pub fn with_transform_currencies(mut self, flag: bool) -> SimpleModel<'a> {
+    #[must_use]
+    pub const fn with_transform_currencies(mut self, flag: bool) -> SimpleModel<'a> {
         self.transform_currencies = flag;
         self
     }

--- a/src/rates/indexstore.rs
+++ b/src/rates/indexstore.rs
@@ -41,6 +41,7 @@ impl ReadIndex for Arc<RwLock<dyn InterestRateIndexTrait>> {
 
 impl IndexStore {
     /// Creates a new `IndexStore` with the given reference date.
+    #[must_use]
     pub fn new(reference_date: Date) -> IndexStore {
         IndexStore {
             reference_date,
@@ -50,7 +51,8 @@ impl IndexStore {
     }
 
     /// Returns the reference date of this index store.
-    pub fn reference_date(&self) -> Date {
+    #[must_use]
+    pub const fn reference_date(&self) -> Date {
         self.reference_date
     }
 
@@ -194,6 +196,7 @@ impl IndexStore {
     }
 
     /// Returns all indices stored in this store.
+    #[must_use]
     pub fn get_all_indices(&self) -> Vec<Arc<RwLock<dyn InterestRateIndexTrait>>> {
         let mut indices = Vec::new();
         for index in self.index_map.values() {
@@ -203,6 +206,7 @@ impl IndexStore {
     }
 
     /// Returns the next available index ID.
+    #[must_use]
     pub fn next_available_id(&self) -> usize {
         let keys = self.index_map.keys();
         let mut max = 0;

--- a/src/rates/interestrate.rs
+++ b/src/rates/interestrate.rs
@@ -26,7 +26,8 @@ pub struct RateDefinition {
 
 impl RateDefinition {
     /// Creates a new `RateDefinition` with the specified day counter, compounding, and frequency.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         day_counter: DayCounter,
         compounding: Compounding,
         frequency: Frequency,
@@ -39,17 +40,20 @@ impl RateDefinition {
     }
 
     /// Returns the compounding method of this rate definition.
-    pub fn compounding(&self) -> Compounding {
+    #[must_use]
+    pub const fn compounding(&self) -> Compounding {
         self.compounding
     }
 
     /// Returns the frequency of this rate definition.
-    pub fn frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn frequency(&self) -> Frequency {
         self.frequency
     }
 
     /// Returns the day counter of this rate definition.
-    pub fn day_counter(&self) -> DayCounter {
+    #[must_use]
+    pub const fn day_counter(&self) -> DayCounter {
         self.day_counter
     }
 }
@@ -84,7 +88,8 @@ pub struct InterestRate {
 
 impl InterestRate {
     /// Creates a new `InterestRate` with the specified rate value and rate definition parameters.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         rate: f64,
         compounding: Compounding,
         frequency: Frequency,
@@ -97,7 +102,8 @@ impl InterestRate {
     }
 
     /// Creates a new `InterestRate` from a rate value and a `RateDefinition`.
-    pub fn from_rate_definition(rate: f64, rate_definition: RateDefinition) -> InterestRate {
+    #[must_use]
+    pub const fn from_rate_definition(rate: f64, rate_definition: RateDefinition) -> InterestRate {
         InterestRate {
             rate,
             rate_definition,
@@ -105,27 +111,32 @@ impl InterestRate {
     }
 
     /// Returns the rate value of this interest rate.
-    pub fn rate(&self) -> f64 {
+    #[must_use]
+    pub const fn rate(&self) -> f64 {
         self.rate
     }
 
     /// Returns the rate definition of this interest rate.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Returns the compounding method of this interest rate.
-    pub fn compounding(&self) -> Compounding {
+    #[must_use]
+    pub const fn compounding(&self) -> Compounding {
         self.rate_definition.compounding()
     }
 
     /// Returns the frequency of this interest rate.
-    pub fn frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn frequency(&self) -> Frequency {
         self.rate_definition.frequency()
     }
 
     /// Returns the day counter of this interest rate.
-    pub fn day_counter(&self) -> DayCounter {
+    #[must_use]
+    pub const fn day_counter(&self) -> DayCounter {
         self.rate_definition.day_counter()
     }
 
@@ -181,6 +192,7 @@ impl InterestRate {
     }
 
     /// Calculates the compound factor between two dates using the day counter.
+    #[must_use]
     pub fn compound_factor(&self, start: Date, end: Date) -> f64 {
         let day_counter = self.day_counter();
         let year_fraction = day_counter.year_fraction(start, end);
@@ -188,6 +200,7 @@ impl InterestRate {
     }
 
     /// Calculates the compound factor from a year fraction.
+    #[must_use]
     pub fn compound_factor_from_yf(&self, year_fraction: f64) -> f64 {
         let rate = self.rate();
         let compounding = self.compounding();
@@ -214,12 +227,14 @@ impl InterestRate {
     }
 
     /// Calculates the discount factor between two dates.
+    #[must_use]
     pub fn discount_factor(&self, start: Date, end: Date) -> f64 {
         1.0 / self.compound_factor(start, end)
     }
 
     /// Calculates the forward rate between two dates with specified compounding and frequency.
-    pub fn forward_rate(
+    #[must_use]
+    pub const fn forward_rate(
         &self,
         _start_date: Date,
         _end_date: Date,

--- a/src/rates/interestrateindex/iborindex.rs
+++ b/src/rates/interestrateindex/iborindex.rs
@@ -49,6 +49,7 @@ pub struct IborIndex {
 
 impl IborIndex {
     /// Creates a new IborIndex with the given reference date.
+    #[must_use]
     pub fn new(reference_date: Date) -> IborIndex {
         IborIndex {
             name: None,
@@ -61,35 +62,41 @@ impl IborIndex {
     }
 
     /// Returns the rate definition for this index.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Sets the name for this index.
+    #[must_use]
     pub fn with_name(mut self, name: Option<String>) -> Self {
         self.name = name;
         self
     }
 
     /// Sets the tenor for this index.
-    pub fn with_tenor(mut self, tenor: Period) -> Self {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = tenor;
         self
     }
 
     /// Sets the tenor from a frequency for this index.
+    #[must_use]
     pub fn with_frequency(mut self, frequency: Frequency) -> Self {
         self.tenor = Period::from_frequency(frequency).expect("Invalid frequency");
         self
     }
 
     /// Sets the rate definition for this index.
-    pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
+    #[must_use]
+    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.rate_definition = rate_definition;
         self
     }
 
     /// Sets the fixings for this index.
+    #[must_use]
     pub fn with_fixings(mut self, fixings: HashMap<Date, f64>) -> Self {
         self.fixings = fixings;
         self

--- a/src/rates/interestrateindex/overnightcompoundedrateindex.rs
+++ b/src/rates/interestrateindex/overnightcompoundedrateindex.rs
@@ -45,6 +45,7 @@ pub struct OvernightCompoundedRateIndex {
 ///
 /// # Returns
 /// The updated index value
+#[must_use]
 pub fn calculate_overnight_index(
     start_date: Date,
     end_date: Date,
@@ -66,6 +67,7 @@ pub fn calculate_overnight_index(
 ///
 /// # Returns
 /// A map of dates to computed index values
+#[must_use]
 pub fn compose_fixing_rate(
     fixings_rates: HashMap<Date, f64>,
     rate_definition: RateDefinition,
@@ -96,6 +98,7 @@ pub fn compose_fixing_rate(
 
 impl OvernightCompoundedRateIndex {
     /// Creates a new `OvernightCompoundedRateIndex` with the given reference date.
+    #[must_use]
     pub fn new(reference_date: Date) -> OvernightCompoundedRateIndex {
         OvernightCompoundedRateIndex {
             fixings_rates: HashMap::new(),
@@ -104,23 +107,27 @@ impl OvernightCompoundedRateIndex {
     }
 
     /// Sets the name for this index.
+    #[must_use]
     pub fn with_name(mut self, name: Option<String>) -> Self {
         self.overnight_index = self.overnight_index.with_name(name);
         self
     }
 
     /// Returns the rate definition for this index.
+    #[must_use]
     pub fn rate_definition(&self) -> RateDefinition {
         self.overnight_index.rate_definition()
     }
 
     /// Sets the rate definition for this index.
+    #[must_use]
     pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.overnight_index = self.overnight_index.with_rate_definition(rate_definition);
         self
     }
 
     /// Sets the overnight fixing rates for this index.
+    #[must_use]
     pub fn with_fixings_rates(mut self, fixings_rates: HashMap<Date, f64>) -> Self {
         self.fixings_rates = fixings_rates.clone();
         let fixing_index = compose_fixing_rate(fixings_rates, self.rate_definition());
@@ -129,7 +136,8 @@ impl OvernightCompoundedRateIndex {
     }
 
     /// Returns a reference to the fixing rates map.
-    pub fn fixings_rates(&self) -> &HashMap<Date, f64> {
+    #[must_use]
+    pub const fn fixings_rates(&self) -> &HashMap<Date, f64> {
         &self.fixings_rates
     }
 

--- a/src/rates/interestrateindex/overnightindex.rs
+++ b/src/rates/interestrateindex/overnightindex.rs
@@ -37,6 +37,7 @@ pub struct OvernightIndex {
 
 impl OvernightIndex {
     /// Creates a new `OvernightIndex` with the given reference date.
+    #[must_use]
     pub fn new(reference_date: Date) -> OvernightIndex {
         OvernightIndex {
             name: None,
@@ -49,23 +50,27 @@ impl OvernightIndex {
     }
 
     /// Sets the name of this overnight index.
+    #[must_use]
     pub fn with_name(mut self, name: Option<String>) -> Self {
         self.name = name;
         self
     }
 
     /// Returns the rate definition of this overnight index.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Sets the rate definition for this overnight index.
-    pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
+    #[must_use]
+    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.rate_definition = rate_definition;
         self
     }
 
     /// Sets the fixings for this overnight index.
+    #[must_use]
     pub fn with_fixings(mut self, fixings: HashMap<Date, f64>) -> Self {
         self.fixings = fixings;
         self

--- a/src/rates/yieldtermstructure/compositetermstructure.rs
+++ b/src/rates/yieldtermstructure/compositetermstructure.rs
@@ -59,11 +59,13 @@ impl CompositeTermStructure {
     }
 
     /// Returns a reference to the spread curve.
+    #[must_use]
     pub fn spread_curve(&self) -> &dyn YieldTermStructureTrait {
         self.spread_curve.as_ref()
     }
 
     /// Returns a reference to the base curve.
+    #[must_use]
     pub fn base_curve(&self) -> &dyn YieldTermStructureTrait {
         self.base_curve.as_ref()
     }

--- a/src/rates/yieldtermstructure/discounttermstructure.rs
+++ b/src/rates/yieldtermstructure/discounttermstructure.rs
@@ -126,27 +126,32 @@ impl DiscountTermStructure {
     }
 
     /// Returns a reference to the vector of dates.
-    pub fn dates(&self) -> &Vec<Date> {
+    #[must_use]
+    pub const fn dates(&self) -> &Vec<Date> {
         &self.dates
     }
 
     /// Returns a reference to the vector of discount factors.
-    pub fn discount_factors(&self) -> &Vec<f64> {
+    #[must_use]
+    pub const fn discount_factors(&self) -> &Vec<f64> {
         &self.discount_factors
     }
 
     /// Returns the day counter convention used.
-    pub fn day_counter(&self) -> DayCounter {
+    #[must_use]
+    pub const fn day_counter(&self) -> DayCounter {
         self.day_counter
     }
 
     /// Returns whether extrapolation is enabled.
-    pub fn enable_extrapolation(&self) -> bool {
+    #[must_use]
+    pub const fn enable_extrapolation(&self) -> bool {
         self.enable_extrapolation
     }
 
     /// Returns the interpolator used.
-    pub fn interpolator(&self) -> Interpolator {
+    #[must_use]
+    pub const fn interpolator(&self) -> Interpolator {
         self.interpolator
     }
 }

--- a/src/rates/yieldtermstructure/flatforwardtermstructure.rs
+++ b/src/rates/yieldtermstructure/flatforwardtermstructure.rs
@@ -30,6 +30,7 @@ pub struct FlatForwardTermStructure {
 
 impl FlatForwardTermStructure {
     /// Creates a new `FlatForwardTermStructure` with the specified reference date, rate, and rate definition.
+    #[must_use]
     pub fn new(
         reference_date: Date,
         rate: f64,
@@ -43,16 +44,19 @@ impl FlatForwardTermStructure {
     }
 
     /// Returns the underlying interest rate.
-    pub fn rate(&self) -> InterestRate {
+    #[must_use]
+    pub const fn rate(&self) -> InterestRate {
         self.rate
     }
 
     /// Returns the rate value.
+    #[must_use]
     pub fn value(&self) -> f64 {
         self.rate.rate()
     }
 
     /// Returns the rate definition.
+    #[must_use]
     pub fn rate_definition(&self) -> RateDefinition {
         self.rate.rate_definition()
     }

--- a/src/rates/yieldtermstructure/tenorbasedzeroratetermstructure.rs
+++ b/src/rates/yieldtermstructure/tenorbasedzeroratetermstructure.rs
@@ -82,12 +82,14 @@ impl TenorBasedZeroRateTermStructure {
     }
 
     /// Returns the tenors of the term structure.
-    pub fn tenors(&self) -> &Vec<Period> {
+    #[must_use]
+    pub const fn tenors(&self) -> &Vec<Period> {
         &self.tenors
     }
 
     /// Returns the spreads of the term structure.
-    pub fn spreads(&self) -> &Vec<f64> {
+    #[must_use]
+    pub const fn spreads(&self) -> &Vec<f64> {
         &self.spreads
     }
 }

--- a/src/rates/yieldtermstructure/zeroratetermstructure.rs
+++ b/src/rates/yieldtermstructure/zeroratetermstructure.rs
@@ -109,27 +109,32 @@ impl ZeroRateTermStructure {
     }
 
     /// Returns a reference to the vector of dates.
-    pub fn dates(&self) -> &Vec<Date> {
+    #[must_use]
+    pub const fn dates(&self) -> &Vec<Date> {
         &self.dates
     }
 
     /// Returns a reference to the vector of zero rates.
-    pub fn rates(&self) -> &Vec<f64> {
+    #[must_use]
+    pub const fn rates(&self) -> &Vec<f64> {
         &self.rates
     }
 
     /// Returns the rate definition used by this term structure.
-    pub fn rate_definition(&self) -> RateDefinition {
+    #[must_use]
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate_definition
     }
 
     /// Returns whether extrapolation is enabled for this term structure.
-    pub fn enable_extrapolation(&self) -> bool {
+    #[must_use]
+    pub const fn enable_extrapolation(&self) -> bool {
         self.enable_extrapolation
     }
 
     /// Returns the interpolator used by this term structure.
-    pub fn interpolator(&self) -> Interpolator {
+    #[must_use]
+    pub const fn interpolator(&self) -> Interpolator {
         self.interpolator
     }
 }

--- a/src/time/calendars/brazil.rs
+++ b/src/time/calendars/brazil.rs
@@ -27,6 +27,7 @@ pub struct Brazil {
 
 impl Brazil {
     /// Creates a new Brazil calendar with the specified market type.
+    #[must_use]
     pub fn new(market: Market) -> Self {
         Brazil {
             market,
@@ -39,51 +40,51 @@ impl Brazil {
         day == Weekday::Sat || day == Weekday::Sun
     }
 
-    fn is_new_years_day(day: u32, month: u32) -> bool {
+    const fn is_new_years_day(day: u32, month: u32) -> bool {
         day == 1 && month == 1
     }
 
-    fn is_sao_paulo_city_day(day: u32, month: u32) -> bool {
+    const fn is_sao_paulo_city_day(day: u32, month: u32) -> bool {
         day == 25 && month == 1
     }
 
-    fn is_tiradentes_day(day: u32, month: u32) -> bool {
+    const fn is_tiradentes_day(day: u32, month: u32) -> bool {
         day == 21 && month == 4
     }
 
-    fn is_labor_day(day: u32, month: u32) -> bool {
+    const fn is_labor_day(day: u32, month: u32) -> bool {
         day == 1 && month == 5
     }
 
-    fn is_revolution_day(day: u32, month: u32) -> bool {
+    const fn is_revolution_day(day: u32, month: u32) -> bool {
         day == 9 && month == 7
     }
 
-    fn is_independence_day(day: u32, month: u32) -> bool {
+    const fn is_independence_day(day: u32, month: u32) -> bool {
         day == 7 && month == 9
     }
 
-    fn is_nossa_senhora_aparecida_day(day: u32, month: u32) -> bool {
+    const fn is_nossa_senhora_aparecida_day(day: u32, month: u32) -> bool {
         day == 12 && month == 10
     }
 
-    fn is_all_souls_day(day: u32, month: u32) -> bool {
+    const fn is_all_souls_day(day: u32, month: u32) -> bool {
         day == 2 && month == 11
     }
 
-    fn is_republic_day(day: u32, month: u32) -> bool {
+    const fn is_republic_day(day: u32, month: u32) -> bool {
         day == 15 && month == 11
     }
 
-    fn is_black_consciousness_day(day: u32, month: u32, year: i32) -> bool {
+    const fn is_black_consciousness_day(day: u32, month: u32, year: i32) -> bool {
         day == 20 && month == 11 && year >= 2007
     }
 
-    fn is_christmas_eve(day: u32, month: u32) -> bool {
+    const fn is_christmas_eve(day: u32, month: u32) -> bool {
         day == 24 && month == 12
     }
 
-    fn is_christmas(day: u32, month: u32) -> bool {
+    const fn is_christmas(day: u32, month: u32) -> bool {
         day == 25 && month == 12
     }
 
@@ -114,6 +115,7 @@ impl Brazil {
     }
 
     /// Checks if the given date is a business day according to the calendar rules.
+    #[must_use]
     pub fn is_business_day(&self, date: NaiveDate) -> bool {
         let weekday = date.weekday();
         let day = date.day();

--- a/src/time/calendars/chile.rs
+++ b/src/time/calendars/chile.rs
@@ -25,6 +25,7 @@ pub struct Chile {
 
 impl Chile {
     /// Creates a new Chile calendar instance for the specified market.
+    #[must_use]
     pub fn new(market: Market) -> Self {
         Self {
             market,
@@ -54,15 +55,15 @@ impl Chile {
         dd == easter_saturday
     }
 
-    fn is_labour_day(day: u32, month: u32) -> bool {
+    const fn is_labour_day(day: u32, month: u32) -> bool {
         day == 1 && month == 5
     }
 
-    fn is_navy_day(day: u32, month: u32) -> bool {
+    const fn is_navy_day(day: u32, month: u32) -> bool {
         day == 21 && month == 5
     }
 
-    fn is_aboriginal_peoples_day(day: u32, month: u32, year: i32) -> bool {
+    const fn is_aboriginal_peoples_day(day: u32, month: u32, year: i32) -> bool {
         day == 21 && month == 6 && year >= 2021
     }
 
@@ -72,11 +73,11 @@ impl Chile {
             || day == 2 && month == 7 && w == Weekday::Mon
     }
 
-    fn is_our_lady_of_mount_carmel_day(day: u32, month: u32) -> bool {
+    const fn is_our_lady_of_mount_carmel_day(day: u32, month: u32) -> bool {
         day == 16 && month == 7
     }
 
-    fn is_assumption_day(day: u32, month: u32) -> bool {
+    const fn is_assumption_day(day: u32, month: u32) -> bool {
         day == 15 && month == 8
     }
 
@@ -106,23 +107,24 @@ impl Chile {
             && year >= 2008
     }
 
-    fn is_all_saints_day(day: u32, month: u32) -> bool {
+    const fn is_all_saints_day(day: u32, month: u32) -> bool {
         day == 1 && month == 11
     }
 
-    fn is_immaculate_conception(day: u32, month: u32) -> bool {
+    const fn is_immaculate_conception(day: u32, month: u32) -> bool {
         day == 8 && month == 12
     }
 
-    fn is_christmas_day(day: u32, month: u32) -> bool {
+    const fn is_christmas_day(day: u32, month: u32) -> bool {
         day == 25 && month == 12
     }
 
-    fn is_bank_holiday(day: u32, month: u32) -> bool {
+    const fn is_bank_holiday(day: u32, month: u32) -> bool {
         day == 31 && month == 12
     }
 
     /// Determines if a given date is a business day in the Chilean market.
+    #[must_use]
     pub fn is_business_day(&self, date: NaiveDate) -> bool {
         let weekday = date.weekday();
         let day = date.day();

--- a/src/time/calendars/nullcalendar.rs
+++ b/src/time/calendars/nullcalendar.rs
@@ -14,6 +14,7 @@ pub struct NullCalendar {
 
 impl NullCalendar {
     /// Creates a new instance of `NullCalendar`.
+    #[must_use]
     pub fn new() -> Self {
         NullCalendar {
             added_holidays: HashSet::new(),

--- a/src/time/calendars/target.rs
+++ b/src/time/calendars/target.rs
@@ -15,6 +15,7 @@ pub struct TARGET {
 
 impl TARGET {
     /// Creates a new TARGET calendar instance.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             added_holidays: HashSet::new(),

--- a/src/time/calendars/traits.rs
+++ b/src/time/calendars/traits.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 /// # Returns
 ///
 /// The day of year (1-366) for Easter Monday in the given year
+#[must_use]
 pub fn easter_monday(y: i32) -> i32 {
     let easter_monday = vec![
         98, 90, 103, 95, 114, 106, 91, 111, 102, // 1901-1909

--- a/src/time/calendars/unitedstates.rs
+++ b/src/time/calendars/unitedstates.rs
@@ -37,6 +37,7 @@ pub struct UnitedStates {
 
 impl UnitedStates {
     /// Creates a new `UnitedStates` calendar for the specified market.
+    #[must_use]
     pub fn new(market: Market) -> Self {
         Self {
             market,
@@ -90,6 +91,7 @@ impl UnitedStates {
     }
 
     /// Determines if the given date is a business day for this calendar's market.
+    #[must_use]
     pub fn is_business_day(&self, date: NaiveDate) -> bool {
         let weekday = date.weekday();
         let day = date.day();

--- a/src/time/calendars/weekendsonly.rs
+++ b/src/time/calendars/weekendsonly.rs
@@ -13,6 +13,7 @@ pub struct WeekendsOnly {
 
 impl WeekendsOnly {
     /// Creates a new `WeekendsOnly` calendar instance.
+    #[must_use]
     pub fn new() -> Self {
         WeekendsOnly {
             added_holidays: HashSet::new(),

--- a/src/time/date.rs
+++ b/src/time/date.rs
@@ -193,6 +193,7 @@ impl<'de> Deserialize<'de> for Date {
 
 impl Date {
     /// Creates a new `Date` from the given year, month, and day.
+    #[must_use]
     pub fn new(year: i32, month: u32, day: u32) -> Date {
         let base_date = NaiveDate::from_ymd_opt(year, month, day);
         match base_date {
@@ -212,69 +213,82 @@ impl Date {
     }
 
     /// Formats this date as a string using the specified format.
+    #[must_use]
     pub fn to_str(&self, fmt: &str) -> String {
         self.base_date.format(fmt).to_string()
     }
 
     /// Returns the underlying `NaiveDate`.
-    pub fn base_date(&self) -> NaiveDate {
+    #[must_use]
+    pub const fn base_date(&self) -> NaiveDate {
         self.base_date
     }
 
     /// Returns the day of the month (1-31).
+    #[must_use]
     pub fn day(&self) -> u32 {
         self.base_date.day()
     }
 
     /// Returns the month of the year (1-12).
+    #[must_use]
     pub fn month(&self) -> u32 {
         self.base_date.month()
     }
 
     /// Returns the year.
+    #[must_use]
     pub fn year(&self) -> i32 {
         self.base_date.year()
     }
 
     /// Returns the number of days in the month of this date.
+    #[must_use]
     pub fn days_in_month(&self) -> i32 {
         self.base_date.days_in_month()
     }
 
     /// Returns the day of year (1-366) for this date.
+    #[must_use]
     pub fn day_of_year(&self) -> i32 {
         self.base_date.day_of_year()
     }
 
     /// Returns whether this date falls in a leap year.
+    #[must_use]
     pub fn date_has_leap_year(&self) -> bool {
         self.base_date.date_has_leap_year()
     }
 
     /// Returns whether the given year is a leap year.
-    pub fn is_leap_year(year: i32) -> bool {
+    #[must_use]
+    pub const fn is_leap_year(year: i32) -> bool {
         year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
     }
 
     /// Advances this date by `n` units of the specified `TimeUnit`.
+    #[must_use]
     pub fn advance(&self, n: i32, units: TimeUnit) -> Date {
         let base_date = self.base_date.advance(n, units);
         Date::from(base_date)
     }
 
     /// Adds a `Period` to this date.
+    #[must_use]
     pub fn add_period(&self, period: Period) -> Date {
         let base_date = self.base_date + period;
         Date::from(base_date)
     }
 
     /// Returns the last day of the month for the given date.
+    #[must_use]
     pub fn end_of_month(date: Date) -> Date {
         let base_date = NaiveDate::end_of_month(date.base_date);
         Date::from(base_date)
     }
 
     /// Returns the nth occurrence of the specified weekday in the given month and year.
+    #[must_use]
     pub fn nth_weekday(n: i32, day_of_week: Weekday, month: u32, year: i32) -> Date {
         let base_date = Date::new(year, month, 1);
         let first = base_date.weekday();
@@ -285,12 +299,14 @@ impl Date {
     }
 
     /// Returns the next occurrence of the specified weekday after the given date.
+    #[must_use]
     pub fn next_weekday(date: Date, weekday: Weekday) -> Date {
         let wd = date.weekday();
         date + ((if wd > weekday { 7 } else { 0 }) - wd + weekday) as i64
     }
 
     /// Returns the day of the week for this date.
+    #[must_use]
     pub fn weekday(&self) -> Weekday {
         match self.base_date.weekday() {
             chrono::Weekday::Mon => Weekday::Monday,
@@ -304,6 +320,7 @@ impl Date {
     }
 
     /// Returns the minimum representable date.
+    #[must_use]
     pub fn empty() -> Date {
         //min
         Date::from(NaiveDate::MIN)

--- a/src/time/daycounter.rs
+++ b/src/time/daycounter.rs
@@ -29,6 +29,7 @@ pub enum DayCounter {
 
 impl DayCounter {
     /// Calculates the day count between two dates using the selected day count convention.
+    #[must_use]
     pub fn day_count(&self, start: Date, end: Date) -> i64 {
         match self {
             DayCounter::Actual360 => Actual360::day_count(start, end),
@@ -41,6 +42,7 @@ impl DayCounter {
     }
 
     /// Calculates the year fraction between two dates using the selected day count convention.
+    #[must_use]
     pub fn year_fraction(&self, start: Date, end: Date) -> f64 {
         match self {
             DayCounter::Actual360 => Actual360::year_fraction(start, end),

--- a/src/time/imm.rs
+++ b/src/time/imm.rs
@@ -10,6 +10,7 @@ impl IMM {
     /// # Arguments
     /// * `date` - The date to check
     /// * `main_cycle` - If true, only checks main cycle months (3, 6, 9, 12)
+    #[must_use]
     pub fn is_imm_date(date: Date, main_cycle: bool) -> bool {
         if date.weekday() != Weekday::Wednesday {
             return false;
@@ -28,6 +29,7 @@ impl IMM {
     /// # Arguments
     /// * `in_` - The code string to validate (e.g., "F3")
     /// * `main_cycle` - If true, only validates main cycle codes
+    #[must_use]
     pub fn is_imm_code(in_: String, main_cycle: bool) -> bool {
         if in_.len() != 2 {
             return false;
@@ -53,6 +55,7 @@ impl IMM {
     ///
     /// # Panics
     /// Panics if the date is not a valid IMM date
+    #[must_use]
     pub fn code(imm_date: Date) -> String {
         if !IMM::is_imm_date(imm_date, false) {
             panic!("{} is not an IMM date", imm_date);
@@ -83,6 +86,7 @@ impl IMM {
     ///
     /// # Panics
     /// Panics if the reference date is empty or the code is invalid
+    #[must_use]
     pub fn date(imm_code: String, reference_date: Date) -> Date {
         if reference_date == Date::empty() {
             panic!("No reference date provided");
@@ -130,6 +134,7 @@ impl IMM {
     ///
     /// # Panics
     /// Panics if the reference date is empty
+    #[must_use]
     pub fn next_date(reference_date: Date, main_cycle: bool) -> Date {
         if reference_date == Date::empty() {
             panic!("No reference date provided");
@@ -161,6 +166,7 @@ impl IMM {
     /// * `imm_code` - The IMM code to start from
     /// * `main_cycle` - If true, only finds dates in main cycle months
     /// * `reference_date` - A reference date to resolve the code
+    #[must_use]
     pub fn next_date_with_code(imm_code: String, main_cycle: bool, reference_date: Date) -> Date {
         let imm_date = IMM::date(imm_code, reference_date);
         IMM::next_date(imm_date + 1, main_cycle)
@@ -171,6 +177,7 @@ impl IMM {
     /// # Arguments
     /// * `d` - The reference date
     /// * `main_cycle` - If true, only considers main cycle months
+    #[must_use]
     pub fn next_code(d: Date, main_cycle: bool) -> String {
         let next = IMM::next_date(d, main_cycle);
         IMM::code(next)
@@ -182,6 +189,7 @@ impl IMM {
     /// * `imm_code` - The current IMM code
     /// * `main_cycle` - If true, only considers main cycle months
     /// * `reference_date` - A reference date to resolve the code
+    #[must_use]
     pub fn next_code_with_code(imm_code: String, main_cycle: bool, reference_date: Date) -> String {
         let imm_date = IMM::date(imm_code, reference_date);
         let next = IMM::next_date(imm_date, main_cycle);

--- a/src/time/period.rs
+++ b/src/time/period.rs
@@ -40,7 +40,8 @@ impl Period {
     /// assert_eq!(p.length(), 5);
     /// assert_eq!(p.units(), TimeUnit::Days);
     /// ```
-    pub fn new(length: i32, units: TimeUnit) -> Period {
+    #[must_use]
+    pub const fn new(length: i32, units: TimeUnit) -> Period {
         Period { length, units }
     }
 
@@ -60,7 +61,8 @@ impl Period {
     /// assert_eq!(p.length(), 1);
     /// assert_eq!(p.units(), TimeUnit::Years);
     /// ```
-    pub fn from_frequency(freq: Frequency) -> Option<Period> {
+    #[must_use]
+    pub const fn from_frequency(freq: Frequency) -> Option<Period> {
         match freq {
             Frequency::NoFrequency => Some(Self {
                 units: TimeUnit::Days,
@@ -103,7 +105,8 @@ impl Period {
     /// let p = Period::new(1, TimeUnit::Years);
     /// assert_eq!(p.frequency(), Frequency::Annual);
     /// ```
-    pub fn frequency(&self) -> Frequency {
+    #[must_use]
+    pub const fn frequency(&self) -> Frequency {
         let length = self.length.abs(); // assuming `length` is i32 or some integer type
 
         if length == 0 {
@@ -166,7 +169,7 @@ impl Period {
     /// assert_eq!(p.length(), 1);
     /// assert_eq!(p.units(), TimeUnit::Years);
     /// ```
-    pub fn normalize(&mut self) {
+    pub const fn normalize(&mut self) {
         if self.length == 0 {
             self.units = TimeUnit::Days;
         }
@@ -197,7 +200,8 @@ impl Period {
     /// let p = Period::new(5, TimeUnit::Days);
     /// assert_eq!(p.length(), 5);
     /// ```
-    pub fn length(&self) -> i32 {
+    #[must_use]
+    pub const fn length(&self) -> i32 {
         self.length
     }
 
@@ -210,7 +214,8 @@ impl Period {
     /// let p = Period::new(5, TimeUnit::Days);
     /// assert_eq!(p.units(), TimeUnit::Days);
     /// ```
-    pub fn units(&self) -> TimeUnit {
+    #[must_use]
+    pub const fn units(&self) -> TimeUnit {
         self.units
     }
 
@@ -224,7 +229,8 @@ impl Period {
     /// assert_eq!(p.length(), 0);
     /// assert_eq!(p.units(), TimeUnit::Days);
     /// ```
-    pub fn empty() -> Self {
+    #[must_use]
+    pub const fn empty() -> Self {
         Self {
             length: 0,
             units: TimeUnit::Days,
@@ -308,6 +314,7 @@ impl Period {
     /// let p = Period::new(6, TimeUnit::Months);
     /// assert_eq!(p.period_in_year(), 0.5);
     /// ```
+    #[must_use]
     pub fn period_in_year(&self) -> f64 {
         match self.units {
             TimeUnit::Years => self.length as f64,

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -87,7 +87,8 @@ pub struct Schedule {
 
 impl Schedule {
     /// Creates a new `Schedule` with the specified parameters.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         tenor: Period,
         calendar: Calendar,
         convention: BusinessDayConvention,
@@ -114,6 +115,7 @@ impl Schedule {
     }
 
     /// Creates an empty `Schedule` with default values.
+    #[must_use]
     pub fn empty() -> Schedule {
         Schedule {
             tenor: Period::empty(),
@@ -130,52 +132,62 @@ impl Schedule {
     }
 
     /// Returns a reference to the dates of the schedule.
-    pub fn dates(&self) -> &Vec<Date> {
+    #[must_use]
+    pub const fn dates(&self) -> &Vec<Date> {
         &self.dates
     }
 
     /// Returns a reference to the regularity vector of the schedule.
-    pub fn is_regular(&self) -> &Vec<bool> {
+    #[must_use]
+    pub const fn is_regular(&self) -> &Vec<bool> {
         &self.is_regular
     }
 
     /// Returns the tenor of the schedule.
-    pub fn tenor(&self) -> Period {
+    #[must_use]
+    pub const fn tenor(&self) -> Period {
         self.tenor
     }
 
     /// Returns the calendar of the schedule.
+    #[must_use]
     pub fn calendar(&self) -> Calendar {
         self.calendar.clone()
     }
 
     /// Returns the business day convention of the schedule.
-    pub fn convention(&self) -> BusinessDayConvention {
+    #[must_use]
+    pub const fn convention(&self) -> BusinessDayConvention {
         self.convention
     }
 
     /// Returns the termination date convention of the schedule.
-    pub fn termination_date_convention(&self) -> BusinessDayConvention {
+    #[must_use]
+    pub const fn termination_date_convention(&self) -> BusinessDayConvention {
         self.termination_date_convention
     }
 
     /// Returns the date generation rule of the schedule.
-    pub fn rule(&self) -> DateGenerationRule {
+    #[must_use]
+    pub const fn rule(&self) -> DateGenerationRule {
         self.rule
     }
 
     /// Returns the end of month flag of the schedule.
-    pub fn end_of_month(&self) -> bool {
+    #[must_use]
+    pub const fn end_of_month(&self) -> bool {
         self.end_of_month
     }
 
     /// Returns the first date of the schedule.
-    pub fn first_date(&self) -> Date {
+    #[must_use]
+    pub const fn first_date(&self) -> Date {
         self.first_date
     }
 
     /// Returns the next to last date of the schedule.
-    pub fn next_to_last_date(&self) -> Date {
+    #[must_use]
+    pub const fn next_to_last_date(&self) -> Date {
         self.next_to_last_date
     }
 }
@@ -223,7 +235,8 @@ pub struct MakeSchedule {
 /// Constructor, setters and getters
 impl MakeSchedule {
     /// Returns a new instance of `MakeSchedule`.
-    pub fn new(from: Date, to: Date) -> MakeSchedule {
+    #[must_use]
+    pub const fn new(from: Date, to: Date) -> MakeSchedule {
         MakeSchedule {
             effective_date: from,
             termination_date: to,
@@ -241,31 +254,36 @@ impl MakeSchedule {
     }
 
     /// Sets the tenor.
-    pub fn with_tenor(mut self, tenor: Period) -> MakeSchedule {
+    #[must_use]
+    pub const fn with_tenor(mut self, tenor: Period) -> MakeSchedule {
         self.tenor = tenor;
         self
     }
 
     /// Sets the frequency.
+    #[must_use]
     pub fn with_frequency(mut self, frequency: Frequency) -> MakeSchedule {
         self.tenor = Period::from_frequency(frequency).expect("Invalid frequency");
         self
     }
 
     /// Sets the calendar.
+    #[must_use]
     pub fn with_calendar(mut self, calendar: Calendar) -> MakeSchedule {
         self.calendar = calendar;
         self
     }
 
     /// Sets the convention. weekday correccions are applied.
-    pub fn with_convention(mut self, convention: BusinessDayConvention) -> MakeSchedule {
+    #[must_use]
+    pub const fn with_convention(mut self, convention: BusinessDayConvention) -> MakeSchedule {
         self.convention = convention;
         self
     }
 
     /// Sets the termination date convention.
-    pub fn with_termination_date_convention(
+    #[must_use]
+    pub const fn with_termination_date_convention(
         mut self,
         termination_date_convention: BusinessDayConvention,
     ) -> MakeSchedule {
@@ -274,37 +292,43 @@ impl MakeSchedule {
     }
 
     /// Sets the rule.
-    pub fn with_rule(mut self, rule: DateGenerationRule) -> MakeSchedule {
+    #[must_use]
+    pub const fn with_rule(mut self, rule: DateGenerationRule) -> MakeSchedule {
         self.rule = rule;
         self
     }
 
     /// Sets the end of month flag.
-    pub fn forwards(mut self) -> MakeSchedule {
+    #[must_use]
+    pub const fn forwards(mut self) -> MakeSchedule {
         self.rule = DateGenerationRule::Forward;
         self
     }
 
     /// Sets the date generation rule to backward.
-    pub fn backwards(mut self) -> MakeSchedule {
+    #[must_use]
+    pub const fn backwards(mut self) -> MakeSchedule {
         self.rule = DateGenerationRule::Backward;
         self
     }
 
     /// Sets the end of month flag.
-    pub fn end_of_month(mut self, flag: bool) -> MakeSchedule {
+    #[must_use]
+    pub const fn end_of_month(mut self, flag: bool) -> MakeSchedule {
         self.end_of_month = flag;
         self
     }
 
     /// Sets the first date.
-    pub fn with_first_date(mut self, first_date: Date) -> MakeSchedule {
+    #[must_use]
+    pub const fn with_first_date(mut self, first_date: Date) -> MakeSchedule {
         self.first_date = first_date;
         self
     }
 
     /// Sets the next to last date.
-    pub fn with_next_to_last_date(mut self, next_to_last_date: Date) -> MakeSchedule {
+    #[must_use]
+    pub const fn with_next_to_last_date(mut self, next_to_last_date: Date) -> MakeSchedule {
         self.next_to_last_date = next_to_last_date;
         self
     }

--- a/src/utils/tools.rs
+++ b/src/utils/tools.rs
@@ -1,4 +1,5 @@
 /// Sorts a slice of strings in alphabetical order and returns a new sorted vector.
+#[must_use]
 pub fn sort_strings_alphabetically(strings: &[String]) -> Vec<String> {
     let mut sorted_strings = strings.to_owned();
     sorted_strings.sort();

--- a/src/visitors/accruedamountconstvisitor.rs
+++ b/src/visitors/accruedamountconstvisitor.rs
@@ -25,6 +25,7 @@ pub struct AccruedAmountConstVisitor {
 
 impl AccruedAmountConstVisitor {
     /// Creates a new `AccruedAmountConstVisitor` with the specified evaluation date and horizon.
+    #[must_use]
     pub fn new(evaluation_date: Date, horizon: Period) -> Self {
         let schedule = MakeSchedule::new(evaluation_date, evaluation_date + horizon)
             .with_tenor(Period::new(1, TimeUnit::Days))
@@ -39,7 +40,7 @@ impl AccruedAmountConstVisitor {
     }
 
     /// Sets the currency to validate against the instrument's currency.
-    pub fn with_validate_currency(mut self, currency: Currency) -> Self {
+    pub const fn with_validate_currency(mut self, currency: Currency) -> Self {
         self.validation_currency = Some(currency);
         self
     }

--- a/src/visitors/durationconstvisitor.rs
+++ b/src/visitors/durationconstvisitor.rs
@@ -23,7 +23,8 @@ impl<'a> DurationConstVisitor<'a> {
     ///
     /// # Arguments
     /// * `market_data` - A slice of market data to use for duration calculations
-    pub fn new(market_data: &'a [MarketData]) -> Self {
+    #[must_use]
+    pub const fn new(market_data: &'a [MarketData]) -> Self {
         DurationConstVisitor { market_data }
     }
 }

--- a/src/visitors/npvconstvisitor.rs
+++ b/src/visitors/npvconstvisitor.rs
@@ -20,14 +20,15 @@ pub struct NPVConstVisitor<'a> {
 
 impl<'a> NPVConstVisitor<'a> {
     /// Creates a new `NPVConstVisitor` with the given market data and flag.
-    pub fn new(market_data: &'a [MarketData], include_today_cashflows: bool) -> Self {
+    #[must_use]
+    pub const fn new(market_data: &'a [MarketData], include_today_cashflows: bool) -> Self {
         NPVConstVisitor {
             market_data,
             include_today_cashflows,
         }
     }
     /// Sets whether to include cashflows with payment date equal to the reference date.
-    pub fn set_include_today_cashflows(&mut self, include_today_cashflows: bool) {
+    pub const fn set_include_today_cashflows(&mut self, include_today_cashflows: bool) {
         self.include_today_cashflows = include_today_cashflows;
     }
 }

--- a/src/visitors/parvaluevisitor.rs
+++ b/src/visitors/parvaluevisitor.rs
@@ -33,7 +33,7 @@ struct ParValue<'a, T> {
 
 impl<'a, T> ParValue<'a, T> {
     #[must_use]
-    pub fn new(eval: &'a T, market_data: &'a [MarketData]) -> Self {
+    pub const fn new(eval: &'a T, market_data: &'a [MarketData]) -> Self {
         let npv_visitor = NPVConstVisitor::new(market_data, true);
         let fixing_visitor = FixingVisitor::new(market_data);
         ParValue {
@@ -92,7 +92,7 @@ pub struct ParValueConstVisitor<'a> {
 impl<'a> ParValueConstVisitor<'a> {
     /// Creates a new `ParValueConstVisitor` with the given market data.
     #[must_use]
-    pub fn new(market_data: &'a [MarketData]) -> Self {
+    pub const fn new(market_data: &'a [MarketData]) -> Self {
         Self { market_data }
     }
 }

--- a/src/visitors/parvaluevisitordoublerateinstrument.rs
+++ b/src/visitors/parvaluevisitordoublerateinstrument.rs
@@ -33,7 +33,7 @@ struct TmpInstrument {
 
 impl TmpInstrument {
     #[must_use]
-    pub fn new(cashflows: Vec<Cashflow>) -> Self {
+    pub const fn new(cashflows: Vec<Cashflow>) -> Self {
         Self { cashflows }
     }
     pub fn set_rate_value(mut self, rate: f64) -> Self {
@@ -63,7 +63,7 @@ struct ParValue<'a, T> {
 
 impl<'a, T> ParValue<'a, T> {
     #[must_use]
-    pub fn new(eval: &'a T, market_data: &'a [MarketData]) -> Self {
+    pub const fn new(eval: &'a T, market_data: &'a [MarketData]) -> Self {
         let npv_visitor = NPVConstVisitor::new(market_data, true);
         let fixing_visitor = FixingVisitor::new(market_data);
         ParValue {
@@ -98,7 +98,7 @@ pub struct ParValueConstVisitor<'a> {
 impl<'a> ParValueConstVisitor<'a> {
     /// Creates a new `ParValueConstVisitor` with the given market data.
     #[must_use]
-    pub fn new(market_data: &'a [MarketData]) -> Self {
+    pub const fn new(market_data: &'a [MarketData]) -> Self {
         Self { market_data }
     }
 }

--- a/src/visitors/zspreadconstvisitor.rs
+++ b/src/visitors/zspreadconstvisitor.rs
@@ -27,7 +27,8 @@ pub struct ZSpreadConstVisitor<'a> {
 
 impl<'a> ZSpreadConstVisitor<'a> {
     /// Creates a new `ZSpreadConstVisitor` with the given market data, rate definition, and target NPV.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         market_data: &'a [MarketData],
         rate_definition: RateDefinition,
         target: f64,


### PR DESCRIPTION
### Motivation
- Address Clippy diagnostics for `must_use_candidate` and `missing_const_for_fn` by explicitly annotating functions and methods that should be used or can be const.
- Reduce bugs caused by accidentally ignoring builder and pure-return values by marking those APIs with `#[must_use]`.
- Allow compile-time use of simple constructors and accessors by converting eligible `fn` signatures to `const fn` where safe.
- Apply consistent API signal semantics across core, instruments, rates, time, calendars, and visitor modules to improve ergonomics and lints.

### Description
- Added `#[must_use]` to many value-returning helpers, builders, and accessors (for example `Currency::details`, date accessors in `Date`, builder `with_*` methods and `new` constructors) to prevent ignored results.
- Converted eligible constructors and simple getters to `const fn` to enable const-evaluation where possible (applied in modules such as `core::meta`, `rates::interestrate`, `time::period`, various `Make*` builders, and many instrument types), affecting 52 files.
- Made a number of small `const`- and `#[must_use]`-related cleanups in calendars, term structures, index stores, visitors, and utility functions to align with the lints (mechanical edits driven by scanning the Clippy log).
- Changes are limited to function/signature annotations and do not alter algorithms, data structures, or public type layouts.

### Testing
- No automated test suite was executed as part of this change.
- Static changes were applied mechanically based on the Clippy report and no runtime behavior changes were introduced by these annotations.
- A full `cargo test` / `cargo clippy` run is recommended before merging to verify no downstream regressions or new lint failures occur.
- Manual review may be required for any functions that became `const fn` to ensure all callers expect const-evaluability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624c914840832d95c1e0d44eacf6ad)