### PR TITLE
Apply Clippy `missing_const_for_fn` suggestions (convert many methods to `const fn`)

### DIFF
--- a/src/alm/cashaccount.rs
+++ b/src/alm/cashaccount.rs
@@ -28,7 +28,7 @@ impl HasCurrency for CashAccount {
 impl CashAccount {
     /// Creates a new empty cash account.
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             amount: RefCell::new(BTreeMap::new()),
             currency: None,

--- a/src/cashflows/floatingratecoupon.rs
+++ b/src/cashflows/floatingratecoupon.rs
@@ -92,7 +92,7 @@ impl FloatingRateCoupon {
     }
 
     /// Sets the forecast curve ID.
-    pub fn set_forecast_curve_id(&mut self, id: usize) {
+    pub const fn set_forecast_curve_id(&mut self, id: usize) {
         self.forecast_curve_id = Some(id);
     }
 
@@ -106,7 +106,7 @@ impl FloatingRateCoupon {
     }
 
     /// Sets the notional amount.
-    pub fn set_notional(&mut self, notional: f64) {
+    pub const fn set_notional(&mut self, notional: f64) {
         self.notional = notional;
     }
 

--- a/src/cashflows/simplecashflow.rs
+++ b/src/cashflows/simplecashflow.rs
@@ -37,7 +37,7 @@ pub struct SimpleCashflow {
 impl SimpleCashflow {
     /// Creates a new `SimpleCashflow` with the given payment date, currency, and side.
     #[must_use]
-    pub fn new(payment_date: Date, currency: Currency, side: Side) -> Self {
+    pub const fn new(payment_date: Date, currency: Currency, side: Side) -> Self {
         Self {
             payment_date,
             currency,
@@ -70,12 +70,12 @@ impl SimpleCashflow {
     }
 
     /// Sets the discount curve ID for this cashflow.
-    pub fn set_discount_curve_id(&mut self, id: usize) {
+    pub const fn set_discount_curve_id(&mut self, id: usize) {
         self.discount_curve_id = Some(id);
     }
 
     /// Sets the amount for this cashflow.
-    pub fn set_amount(&mut self, amount: f64) {
+    pub const fn set_amount(&mut self, amount: f64) {
         self.amount = Some(amount);
     }
 }

--- a/src/core/meta.rs
+++ b/src/core/meta.rs
@@ -23,7 +23,7 @@ pub struct ExchangeRateRequest {
 impl ExchangeRateRequest {
     /// Creates a new `ExchangeRateRequest`.
     #[must_use]
-    pub fn new(
+    pub const fn new(
         first_currency: Currency,
         second_currency: Option<Currency>,
         reference_date: Option<Date>,

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -103,7 +103,7 @@ impl HasCashflows for Instrument {
 impl Instrument {
     /// Returns the notional value of the instrument.
     #[must_use]
-    pub fn notional(&self) -> f64 {
+    pub const fn notional(&self) -> f64 {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.notional(),
             Instrument::FloatingRateInstrument(fri) => fri.notional(),
@@ -114,7 +114,7 @@ impl Instrument {
 
     /// Returns the start date of the instrument.
     #[must_use]
-    pub fn start_date(&self) -> Date {
+    pub const fn start_date(&self) -> Date {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.start_date(),
             Instrument::FloatingRateInstrument(fri) => fri.start_date(),
@@ -125,7 +125,7 @@ impl Instrument {
 
     /// Returns the end date of the instrument.
     #[must_use]
-    pub fn end_date(&self) -> Date {
+    pub const fn end_date(&self) -> Date {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.end_date(),
             Instrument::FloatingRateInstrument(fri) => fri.end_date(),
@@ -158,7 +158,7 @@ impl Instrument {
 
     /// Returns the payment frequency of the instrument.
     #[must_use]
-    pub fn payment_frequency(&self) -> Frequency {
+    pub const fn payment_frequency(&self) -> Frequency {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.payment_frequency(),
             Instrument::FloatingRateInstrument(fri) => fri.payment_frequency(),
@@ -169,7 +169,7 @@ impl Instrument {
 
     /// Returns the side of the instrument.
     #[must_use]
-    pub fn side(&self) -> Option<Side> {
+    pub const fn side(&self) -> Option<Side> {
         match self {
             Instrument::FixedRateInstrument(fri) => Some(fri.side()),
             Instrument::FloatingRateInstrument(fri) => Some(fri.side()),
@@ -180,7 +180,7 @@ impl Instrument {
 
     /// Returns the issue date of the instrument.
     #[must_use]
-    pub fn issue_date(&self) -> Option<Date> {
+    pub const fn issue_date(&self) -> Option<Date> {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.issue_date(),
             Instrument::FloatingRateInstrument(fri) => fri.issue_date(),
@@ -191,7 +191,7 @@ impl Instrument {
 
     /// Returns the rate type of the instrument.
     #[must_use]
-    pub fn rate_type(&self) -> RateType {
+    pub const fn rate_type(&self) -> RateType {
         match self {
             Instrument::FixedRateInstrument(_) => RateType::Fixed,
             Instrument::FloatingRateInstrument(_) => RateType::Floating,
@@ -224,7 +224,7 @@ impl Instrument {
 
     /// Returns the forecast curve identifier of the instrument.
     #[must_use]
-    pub fn forecast_curve_id(&self) -> Option<usize> {
+    pub const fn forecast_curve_id(&self) -> Option<usize> {
         match self {
             Instrument::FixedRateInstrument(_) => None,
             Instrument::FloatingRateInstrument(fri) => fri.forecast_curve_id(),
@@ -235,7 +235,7 @@ impl Instrument {
 
     /// Returns the discount curve identifier of the instrument.
     #[must_use]
-    pub fn discount_curve_id(&self) -> Option<usize> {
+    pub const fn discount_curve_id(&self) -> Option<usize> {
         match self {
             Instrument::FixedRateInstrument(fri) => fri.discount_curve_id(),
             Instrument::FloatingRateInstrument(fri) => fri.discount_curve_id(),
@@ -266,7 +266,7 @@ impl Instrument {
 
     /// Returns the first rate definition of the instrument.
     #[must_use]
-    pub fn first_rate_definition(&self) -> Option<RateDefinition> {
+    pub const fn first_rate_definition(&self) -> Option<RateDefinition> {
         match self {
             Instrument::FixedRateInstrument(fri) => Some(fri.rate().rate_definition()),
             Instrument::FloatingRateInstrument(fri) => Some(fri.rate_definition()),
@@ -277,7 +277,7 @@ impl Instrument {
 
     /// Returns the second rate definition of the instrument.
     #[must_use]
-    pub fn second_rate_definition(&self) -> Option<RateDefinition> {
+    pub const fn second_rate_definition(&self) -> Option<RateDefinition> {
         match self {
             Instrument::FixedRateInstrument(_) => None,
             Instrument::FloatingRateInstrument(_) => None,

--- a/src/instruments/makefixedrateinstrument.rs
+++ b/src/instruments/makefixedrateinstrument.rs
@@ -177,7 +177,7 @@ impl MakeFixedRateInstrument {
 
     /// Sets the rate definition.
     #[must_use]
-    pub fn with_rate_definition(
+    pub const fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
     ) -> MakeFixedRateInstrument {
@@ -207,7 +207,7 @@ impl MakeFixedRateInstrument {
 
     /// Sets the rate value.
     #[must_use]
-    pub fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateInstrument {
+    pub const fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateInstrument {
         self.rate_value = Some(rate_value);
         match self.rate {
             Some(rate) => {

--- a/src/instruments/makefixedrateleg.rs
+++ b/src/instruments/makefixedrateleg.rs
@@ -172,7 +172,10 @@ impl MakeFixedRateLeg {
 
     /// Sets the rate definition.
     #[must_use]
-    pub fn with_rate_definition(mut self, rate_definition: RateDefinition) -> MakeFixedRateLeg {
+    pub const fn with_rate_definition(
+        mut self,
+        rate_definition: RateDefinition,
+    ) -> MakeFixedRateLeg {
         self.rate_definition = Some(rate_definition);
         match self.rate_value {
             Some(rate_value) => {
@@ -199,7 +202,7 @@ impl MakeFixedRateLeg {
 
     /// Sets the rate value.
     #[must_use]
-    pub fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateLeg {
+    pub const fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateLeg {
         self.rate_value = Some(rate_value);
         match self.rate {
             Some(rate) => {

--- a/src/rates/interestrateindex/overnightcompoundedrateindex.rs
+++ b/src/rates/interestrateindex/overnightcompoundedrateindex.rs
@@ -115,7 +115,7 @@ impl OvernightCompoundedRateIndex {
 
     /// Returns the rate definition for this index.
     #[must_use]
-    pub fn rate_definition(&self) -> RateDefinition {
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.overnight_index.rate_definition()
     }
 

--- a/src/rates/yieldtermstructure/flatforwardtermstructure.rs
+++ b/src/rates/yieldtermstructure/flatforwardtermstructure.rs
@@ -31,7 +31,7 @@ pub struct FlatForwardTermStructure {
 impl FlatForwardTermStructure {
     /// Creates a new `FlatForwardTermStructure` with the specified reference date, rate, and rate definition.
     #[must_use]
-    pub fn new(
+    pub const fn new(
         reference_date: Date,
         rate: f64,
         rate_definition: RateDefinition,
@@ -51,13 +51,13 @@ impl FlatForwardTermStructure {
 
     /// Returns the rate value.
     #[must_use]
-    pub fn value(&self) -> f64 {
+    pub const fn value(&self) -> f64 {
         self.rate.rate()
     }
 
     /// Returns the rate definition.
     #[must_use]
-    pub fn rate_definition(&self) -> RateDefinition {
+    pub const fn rate_definition(&self) -> RateDefinition {
         self.rate.rate_definition()
     }
 }

--- a/src/time/daycounters/actualactual.rs
+++ b/src/time/daycounters/actualactual.rs
@@ -20,7 +20,7 @@ use crate::time::date::Date;
 /// ```
 pub struct ActualActual;
 
-fn days_in_year(year: i32) -> i32 {
+const fn days_in_year(year: i32) -> i32 {
     if Date::is_leap_year(year) {
         366
     } else {

--- a/src/time/daycounters/thirty360.rs
+++ b/src/time/daycounters/thirty360.rs
@@ -56,7 +56,7 @@ impl DayCountProvider for Thirty360 {
 /// ```
 pub struct Thirty360US;
 
-fn is_last_of_february(d: i64, m: i64, y: i32) -> bool {
+const fn is_last_of_february(d: i64, m: i64, y: i32) -> bool {
     if Date::is_leap_year(y) {
         m == 2 && d == 28 + 1
     } else {


### PR DESCRIPTION
### Motivation

- Reduce a large set of Clippy `missing_const_for_fn` warnings by making functions `const` where safe and appropriate.  
- Allow more APIs and helpers to be usable in constant contexts (constructors, simple getters and setters).  
- Address a subset of lints surfaced by the provided `clippy.log` to improve static-check hygiene without changing runtime behaviour.

### Description

- Converted many simple constructors, accessors and setters to `const fn`, e.g. `CashAccount::new`, `SimpleCashflow::new`, `SimpleCashflow::set_amount`, `FloatingRateCoupon::set_notional`, and `ExchangeRateRequest::new` (files updated include `src/alm/cashaccount.rs`, `src/cashflows/simplecashflow.rs`, `src/cashflows/floatingratecoupon.rs`, and `src/core/meta.rs`).
- Made a number of `Instrument` accessors `const fn` to satisfy Clippy suggestions (updated `src/instruments/instrument.rs`).
- Updated builder/utility methods in the fixed-rate instrument helpers to be `const fn` where possible (`src/instruments/makefixedrateinstrument.rs` and `src/instruments/makefixedrateleg.rs`).
- Marked additional term-structure and index accessors and day-counter helpers as `const fn`, including `FlatForwardTermStructure::new/value/rate_definition`, `OvernightCompoundedRateIndex::rate_definition`, and helper functions in day counters (`src/rates/yieldtermstructure/flatforwardtermstructure.rs`, `src/rates/interestrateindex/overnightcompoundedrateindex.rs`, `src/time/daycounters/actualactual.rs`, and `src/time/daycounters/thirty360.rs`).

### Testing

- No automated tests were executed as part of this change.  
- Changes were driven by static analysis from the provided `clippy.log` and implemented where `const`-qualification was safe and compatible with existing APIs.  
- No behavioural or runtime logic was intentionally modified; these edits are keeping function semantics identical while enabling `const` use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637c136998832d94f59da00fe58243)