### PR TITLE
Fix Self replacements, restore builder types and Date signatures, run tests

### DIFF
--- a/src/core/meta.rs
+++ b/src/core/meta.rs
@@ -27,8 +27,8 @@ impl ExchangeRateRequest {
         first_currency: Currency,
         second_currency: Option<Currency>,
         reference_date: Option<Date>,
-    ) -> ExchangeRateRequest {
-        ExchangeRateRequest {
+    ) -> Self {
+        Self {
             first_currency,
             second_currency,
             reference_date,
@@ -70,8 +70,8 @@ pub struct DiscountFactorRequest {
 impl DiscountFactorRequest {
     /// Creates a new `DiscountFactorRequest`.
     #[must_use]
-    pub const fn new(provider_id: usize, date: Date) -> DiscountFactorRequest {
-        DiscountFactorRequest { provider_id, date }
+    pub const fn new(provider_id: usize, date: Date) -> Self {
+        Self { provider_id, date }
     }
 
     /// Returns the provider id.
@@ -117,8 +117,8 @@ impl ForwardRateRequest {
         end_date: Date,
         compounding: Compounding,
         frequency: Frequency,
-    ) -> ForwardRateRequest {
-        ForwardRateRequest {
+    ) -> Self {
+        Self {
             provider_id,
             fixing_date,
             start_date,
@@ -183,8 +183,8 @@ impl MarketRequest {
         df: Option<DiscountFactorRequest>,
         fwd: Option<ForwardRateRequest>,
         fx: Option<ExchangeRateRequest>,
-    ) -> MarketRequest {
-        MarketRequest { id, df, fwd, fx }
+    ) -> Self {
+        Self { id, df, fwd, fx }
     }
 
     /// Returns the id.
@@ -240,8 +240,8 @@ impl MarketData {
         fwd: Option<f64>,
         fx: Option<f64>,
         numerarie: f64,
-    ) -> MarketData {
-        MarketData {
+    ) -> Self {
+        Self {
             id,
             reference_date,
             df,

--- a/src/currencies/exchangeratestore.rs
+++ b/src/currencies/exchangeratestore.rs
@@ -28,8 +28,8 @@ pub struct ExchangeRateStore {
 impl ExchangeRateStore {
     /// Creates a new `ExchangeRateStore` with the given reference date.
     #[must_use]
-    pub fn new(date: Date) -> ExchangeRateStore {
-        ExchangeRateStore {
+    pub fn new(date: Date) -> Self {
+        Self {
             reference_date: date,
             exchange_rate_map: HashMap::new(),
             exchange_rate_cache: Arc::new(Mutex::new(HashMap::new())),
@@ -117,19 +117,19 @@ impl AdvanceExchangeRateStoreInTime for ExchangeRateStore {
         &self,
         period: Period,
         index_store: &IndexStore,
-    ) -> Result<ExchangeRateStore> {
+    ) -> Result<Self> {
         let new_date = self.reference_date + period;
         self.advance_to_date(new_date, index_store)
     }
 
-    fn advance_to_date(&self, date: Date, index_store: &IndexStore) -> Result<ExchangeRateStore> {
+    fn advance_to_date(&self, date: Date, index_store: &IndexStore) -> Result<Self> {
         if self.reference_date() != index_store.reference_date() {
             return Err(AtlasError::InvalidValueErr(
                 "Reference date of exchange rate store and index store do not match".to_string(),
             ));
         }
 
-        let mut new_store = ExchangeRateStore::new(date);
+        let mut new_store = Self::new(date);
         for ((ccy1, ccy2), fx) in self.exchange_rate_map.iter() {
             let compound_factor = index_store.currency_forescast_factor(*ccy1, *ccy2, date);
             match compound_factor {

--- a/src/instruments/doublerateinstrument.rs
+++ b/src/instruments/doublerateinstrument.rs
@@ -64,7 +64,7 @@ impl DoubleRateInstrument {
         discount_curve_id: Option<usize>,
         cashflows: Vec<Cashflow>,
     ) -> Self {
-        DoubleRateInstrument {
+        Self {
             start_date,
             end_date,
             notional,

--- a/src/instruments/fixedrateinstrument.rs
+++ b/src/instruments/fixedrateinstrument.rs
@@ -60,7 +60,7 @@ impl FixedRateInstrument {
         issue_date: Option<Date>,
         yield_rate: Option<InterestRate>,
     ) -> Self {
-        FixedRateInstrument {
+        Self {
             start_date,
             end_date,
             notional,

--- a/src/instruments/floatingrateinstrument.rs
+++ b/src/instruments/floatingrateinstrument.rs
@@ -66,7 +66,7 @@ impl FloatingRateInstrument {
         id: Option<String>,
         issue_date: Option<Date>,
     ) -> Self {
-        FloatingRateInstrument {
+        Self {
             start_date,
             end_date,
             notional,

--- a/src/instruments/hybridrateinstrument.rs
+++ b/src/instruments/hybridrateinstrument.rs
@@ -56,7 +56,7 @@ impl HybridRateInstrument {
         discount_curve_id: Option<usize>,
         cashflows: Vec<Cashflow>,
     ) -> Self {
-        HybridRateInstrument {
+        Self {
             start_date,
             end_date,
             notional,

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -38,12 +38,12 @@ impl TryFrom<String> for RateType {
     type Error = AtlasError;
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Fixed" => Ok(RateType::Fixed),
-            "Floating" => Ok(RateType::Floating),
-            "FixedThenFloating" => Ok(RateType::FixedThenFloating),
-            "FloatingThenFixed" => Ok(RateType::FloatingThenFixed),
-            "FixedThenFixed" => Ok(RateType::FixedThenFixed),
-            "Suffled" => Ok(RateType::Suffled),
+            "Fixed" => Ok(Self::Fixed),
+            "Floating" => Ok(Self::Floating),
+            "FixedThenFloating" => Ok(Self::FixedThenFloating),
+            "FloatingThenFixed" => Ok(Self::FloatingThenFixed),
+            "FixedThenFixed" => Ok(Self::FixedThenFixed),
+            "Suffled" => Ok(Self::Suffled),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid rate type: {}",
                 s
@@ -83,19 +83,19 @@ pub enum Instrument {
 impl HasCashflows for Instrument {
     fn cashflows(&self) -> &[Cashflow] {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.cashflows(),
-            Instrument::FloatingRateInstrument(fri) => fri.cashflows(),
-            Instrument::HybridRateInstrument(hri) => hri.cashflows(),
-            Instrument::DoubleRateInstrument(dri) => dri.cashflows(),
+            Self::FixedRateInstrument(fri) => fri.cashflows(),
+            Self::FloatingRateInstrument(fri) => fri.cashflows(),
+            Self::HybridRateInstrument(hri) => hri.cashflows(),
+            Self::DoubleRateInstrument(dri) => dri.cashflows(),
         }
     }
 
     fn mut_cashflows(&mut self) -> &mut [Cashflow] {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.mut_cashflows(),
-            Instrument::FloatingRateInstrument(fri) => fri.mut_cashflows(),
-            Instrument::HybridRateInstrument(hri) => hri.mut_cashflows(),
-            Instrument::DoubleRateInstrument(dri) => dri.mut_cashflows(),
+            Self::FixedRateInstrument(fri) => fri.mut_cashflows(),
+            Self::FloatingRateInstrument(fri) => fri.mut_cashflows(),
+            Self::HybridRateInstrument(hri) => hri.mut_cashflows(),
+            Self::DoubleRateInstrument(dri) => dri.mut_cashflows(),
         }
     }
 }
@@ -105,10 +105,10 @@ impl Instrument {
     #[must_use]
     pub const fn notional(&self) -> f64 {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.notional(),
-            Instrument::FloatingRateInstrument(fri) => fri.notional(),
-            Instrument::HybridRateInstrument(hri) => hri.notional(),
-            Instrument::DoubleRateInstrument(dri) => dri.notional(),
+            Self::FixedRateInstrument(fri) => fri.notional(),
+            Self::FloatingRateInstrument(fri) => fri.notional(),
+            Self::HybridRateInstrument(hri) => hri.notional(),
+            Self::DoubleRateInstrument(dri) => dri.notional(),
         }
     }
 
@@ -116,10 +116,10 @@ impl Instrument {
     #[must_use]
     pub const fn start_date(&self) -> Date {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.start_date(),
-            Instrument::FloatingRateInstrument(fri) => fri.start_date(),
-            Instrument::HybridRateInstrument(hri) => hri.start_date(),
-            Instrument::DoubleRateInstrument(dri) => dri.start_date(),
+            Self::FixedRateInstrument(fri) => fri.start_date(),
+            Self::FloatingRateInstrument(fri) => fri.start_date(),
+            Self::HybridRateInstrument(hri) => hri.start_date(),
+            Self::DoubleRateInstrument(dri) => dri.start_date(),
         }
     }
 
@@ -127,10 +127,10 @@ impl Instrument {
     #[must_use]
     pub const fn end_date(&self) -> Date {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.end_date(),
-            Instrument::FloatingRateInstrument(fri) => fri.end_date(),
-            Instrument::HybridRateInstrument(hri) => hri.end_date(),
-            Instrument::DoubleRateInstrument(dri) => dri.end_date(),
+            Self::FixedRateInstrument(fri) => fri.end_date(),
+            Self::FloatingRateInstrument(fri) => fri.end_date(),
+            Self::HybridRateInstrument(hri) => hri.end_date(),
+            Self::DoubleRateInstrument(dri) => dri.end_date(),
         }
     }
 
@@ -138,10 +138,10 @@ impl Instrument {
     #[must_use]
     pub fn id(&self) -> Option<String> {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.id(),
-            Instrument::FloatingRateInstrument(fri) => fri.id(),
-            Instrument::HybridRateInstrument(hri) => hri.id(),
-            Instrument::DoubleRateInstrument(dri) => dri.id(),
+            Self::FixedRateInstrument(fri) => fri.id(),
+            Self::FloatingRateInstrument(fri) => fri.id(),
+            Self::HybridRateInstrument(hri) => hri.id(),
+            Self::DoubleRateInstrument(dri) => dri.id(),
         }
     }
 
@@ -149,9 +149,9 @@ impl Instrument {
     #[must_use]
     pub fn structure(&self) -> Structure {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.structure(),
-            Instrument::FloatingRateInstrument(fri) => fri.structure(),
-            Instrument::HybridRateInstrument(hri) => hri.structure(),
+            Self::FixedRateInstrument(fri) => fri.structure(),
+            Self::FloatingRateInstrument(fri) => fri.structure(),
+            Self::HybridRateInstrument(hri) => hri.structure(),
             _ => todo!(),
         }
     }
@@ -160,10 +160,10 @@ impl Instrument {
     #[must_use]
     pub const fn payment_frequency(&self) -> Frequency {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.payment_frequency(),
-            Instrument::FloatingRateInstrument(fri) => fri.payment_frequency(),
-            Instrument::HybridRateInstrument(hri) => hri.payment_frequency(),
-            Instrument::DoubleRateInstrument(dri) => dri.payment_frequency(),
+            Self::FixedRateInstrument(fri) => fri.payment_frequency(),
+            Self::FloatingRateInstrument(fri) => fri.payment_frequency(),
+            Self::HybridRateInstrument(hri) => hri.payment_frequency(),
+            Self::DoubleRateInstrument(dri) => dri.payment_frequency(),
         }
     }
 
@@ -171,10 +171,10 @@ impl Instrument {
     #[must_use]
     pub const fn side(&self) -> Option<Side> {
         match self {
-            Instrument::FixedRateInstrument(fri) => Some(fri.side()),
-            Instrument::FloatingRateInstrument(fri) => Some(fri.side()),
-            Instrument::HybridRateInstrument(hri) => hri.side(),
-            Instrument::DoubleRateInstrument(dri) => Some(dri.side()),
+            Self::FixedRateInstrument(fri) => Some(fri.side()),
+            Self::FloatingRateInstrument(fri) => Some(fri.side()),
+            Self::HybridRateInstrument(hri) => hri.side(),
+            Self::DoubleRateInstrument(dri) => Some(dri.side()),
         }
     }
 
@@ -182,10 +182,10 @@ impl Instrument {
     #[must_use]
     pub const fn issue_date(&self) -> Option<Date> {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.issue_date(),
-            Instrument::FloatingRateInstrument(fri) => fri.issue_date(),
-            Instrument::HybridRateInstrument(hri) => hri.issue_date(),
-            Instrument::DoubleRateInstrument(dri) => dri.issue_date(),
+            Self::FixedRateInstrument(fri) => fri.issue_date(),
+            Self::FloatingRateInstrument(fri) => fri.issue_date(),
+            Self::HybridRateInstrument(hri) => hri.issue_date(),
+            Self::DoubleRateInstrument(dri) => dri.issue_date(),
         }
     }
 
@@ -193,10 +193,10 @@ impl Instrument {
     #[must_use]
     pub const fn rate_type(&self) -> RateType {
         match self {
-            Instrument::FixedRateInstrument(_) => RateType::Fixed,
-            Instrument::FloatingRateInstrument(_) => RateType::Floating,
-            Instrument::HybridRateInstrument(hri) => hri.rate_type(),
-            Instrument::DoubleRateInstrument(dri) => dri.rate_type(),
+            Self::FixedRateInstrument(_) => RateType::Fixed,
+            Self::FloatingRateInstrument(_) => RateType::Floating,
+            Self::HybridRateInstrument(hri) => hri.rate_type(),
+            Self::DoubleRateInstrument(dri) => dri.rate_type(),
         }
     }
 
@@ -204,10 +204,10 @@ impl Instrument {
     #[must_use]
     pub fn rate(&self) -> Option<f64> {
         match self {
-            Instrument::FixedRateInstrument(fri) => Some(fri.rate().rate()),
-            Instrument::FloatingRateInstrument(_) => None,
-            Instrument::HybridRateInstrument(_) => todo!(),
-            Instrument::DoubleRateInstrument(_) => todo!(),
+            Self::FixedRateInstrument(fri) => Some(fri.rate().rate()),
+            Self::FloatingRateInstrument(_) => None,
+            Self::HybridRateInstrument(_) => todo!(),
+            Self::DoubleRateInstrument(_) => todo!(),
         }
     }
 
@@ -215,10 +215,10 @@ impl Instrument {
     #[must_use]
     pub fn spread(&self) -> Option<f64> {
         match self {
-            Instrument::FixedRateInstrument(_) => None,
-            Instrument::FloatingRateInstrument(fri) => Some(fri.spread()),
-            Instrument::HybridRateInstrument(_) => todo!(),
-            Instrument::DoubleRateInstrument(_) => todo!(),
+            Self::FixedRateInstrument(_) => None,
+            Self::FloatingRateInstrument(fri) => Some(fri.spread()),
+            Self::HybridRateInstrument(_) => todo!(),
+            Self::DoubleRateInstrument(_) => todo!(),
         }
     }
 
@@ -226,10 +226,10 @@ impl Instrument {
     #[must_use]
     pub const fn forecast_curve_id(&self) -> Option<usize> {
         match self {
-            Instrument::FixedRateInstrument(_) => None,
-            Instrument::FloatingRateInstrument(fri) => fri.forecast_curve_id(),
-            Instrument::HybridRateInstrument(hri) => hri.forecast_curve_id(),
-            Instrument::DoubleRateInstrument(dri) => dri.forecast_curve_id(),
+            Self::FixedRateInstrument(_) => None,
+            Self::FloatingRateInstrument(fri) => fri.forecast_curve_id(),
+            Self::HybridRateInstrument(hri) => hri.forecast_curve_id(),
+            Self::DoubleRateInstrument(dri) => dri.forecast_curve_id(),
         }
     }
 
@@ -237,29 +237,29 @@ impl Instrument {
     #[must_use]
     pub const fn discount_curve_id(&self) -> Option<usize> {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.discount_curve_id(),
-            Instrument::FloatingRateInstrument(fri) => fri.discount_curve_id(),
-            Instrument::HybridRateInstrument(hri) => hri.discount_curve_id(),
-            Instrument::DoubleRateInstrument(dri) => dri.discount_curve_id(),
+            Self::FixedRateInstrument(fri) => fri.discount_curve_id(),
+            Self::FloatingRateInstrument(fri) => fri.discount_curve_id(),
+            Self::HybridRateInstrument(hri) => hri.discount_curve_id(),
+            Self::DoubleRateInstrument(dri) => dri.discount_curve_id(),
         }
     }
 
     /// Sets the discount curve identifier for the instrument.
     pub fn set_discount_curve_id(&mut self, id: usize) {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.set_discount_curve_id(id),
-            Instrument::FloatingRateInstrument(fri) => fri.set_discount_curve_id(id),
-            Instrument::HybridRateInstrument(hri) => hri.set_discount_curve_id(id),
-            Instrument::DoubleRateInstrument(dri) => dri.set_discount_curve_id(id),
+            Self::FixedRateInstrument(fri) => fri.set_discount_curve_id(id),
+            Self::FloatingRateInstrument(fri) => fri.set_discount_curve_id(id),
+            Self::HybridRateInstrument(hri) => hri.set_discount_curve_id(id),
+            Self::DoubleRateInstrument(dri) => dri.set_discount_curve_id(id),
         }
     }
 
     /// Sets the forecast curve identifier for the instrument.
     pub fn set_forecast_curve_id(&mut self, id: usize) {
         match self {
-            Instrument::FloatingRateInstrument(fri) => fri.set_forecast_curve_id(id),
-            Instrument::HybridRateInstrument(hri) => hri.set_forecast_curve_id(id),
-            Instrument::DoubleRateInstrument(dri) => dri.set_forecast_curve_id(id),
+            Self::FloatingRateInstrument(fri) => fri.set_forecast_curve_id(id),
+            Self::HybridRateInstrument(hri) => hri.set_forecast_curve_id(id),
+            Self::DoubleRateInstrument(dri) => dri.set_forecast_curve_id(id),
             _ => {}
         }
     }
@@ -268,10 +268,10 @@ impl Instrument {
     #[must_use]
     pub const fn first_rate_definition(&self) -> Option<RateDefinition> {
         match self {
-            Instrument::FixedRateInstrument(fri) => Some(fri.rate().rate_definition()),
-            Instrument::FloatingRateInstrument(fri) => Some(fri.rate_definition()),
-            Instrument::HybridRateInstrument(hri) => hri.first_rate_definition(),
-            Instrument::DoubleRateInstrument(dri) => dri.first_rate_definition(),
+            Self::FixedRateInstrument(fri) => Some(fri.rate().rate_definition()),
+            Self::FloatingRateInstrument(fri) => Some(fri.rate_definition()),
+            Self::HybridRateInstrument(hri) => hri.first_rate_definition(),
+            Self::DoubleRateInstrument(dri) => dri.first_rate_definition(),
         }
     }
 
@@ -279,10 +279,10 @@ impl Instrument {
     #[must_use]
     pub const fn second_rate_definition(&self) -> Option<RateDefinition> {
         match self {
-            Instrument::FixedRateInstrument(_) => None,
-            Instrument::FloatingRateInstrument(_) => None,
-            Instrument::HybridRateInstrument(hri) => hri.second_rate_definition(),
-            Instrument::DoubleRateInstrument(dri) => dri.second_rate_definition(),
+            Self::FixedRateInstrument(_) => None,
+            Self::FloatingRateInstrument(_) => None,
+            Self::HybridRateInstrument(hri) => hri.second_rate_definition(),
+            Self::DoubleRateInstrument(dri) => dri.second_rate_definition(),
         }
     }
 }
@@ -290,10 +290,10 @@ impl Instrument {
 impl HasCurrency for Instrument {
     fn currency(&self) -> Result<Currency> {
         match self {
-            Instrument::FixedRateInstrument(fri) => fri.currency(),
-            Instrument::FloatingRateInstrument(fri) => fri.currency(),
-            Instrument::HybridRateInstrument(hri) => hri.currency(),
-            Instrument::DoubleRateInstrument(dri) => dri.currency(),
+            Self::FixedRateInstrument(fri) => fri.currency(),
+            Self::FloatingRateInstrument(fri) => fri.currency(),
+            Self::HybridRateInstrument(hri) => hri.currency(),
+            Self::DoubleRateInstrument(dri) => dri.currency(),
         }
     }
 }

--- a/src/instruments/leg.rs
+++ b/src/instruments/leg.rs
@@ -36,7 +36,7 @@ impl Leg {
         forecast_curve_id: Option<usize>,
         cashflows: Vec<Cashflow>,
     ) -> Self {
-        Leg {
+        Self {
             structure,
             rate_type,
             rate_value,

--- a/src/instruments/loandepo.rs
+++ b/src/instruments/loandepo.rs
@@ -148,7 +148,7 @@ pub struct LoanDepo {
 impl TryFrom<LoanDepo> for Instrument {
     type Error = AtlasError;
 
-    fn try_from(value: LoanDepo) -> Result<Instrument> {
+    fn try_from(value: LoanDepo) -> Result<Self> {
         let mut cashflows = value.cashflows.clone();
         cashflows.iter_mut().try_for_each(|cf| -> Result<()> {
             match cf {
@@ -329,7 +329,7 @@ impl TryFrom<LoanDepo> for Instrument {
                     None,
                 );
 
-                Ok(Instrument::FixedRateInstrument(instrument))
+                Ok(Self::FixedRateInstrument(instrument))
             }
             RateType::Floating => {
                 let (rate, rate_definition) = match value.evaluation_mode {
@@ -367,7 +367,7 @@ impl TryFrom<LoanDepo> for Instrument {
                     Some(value.mis_id),
                     value.issue_date,
                 );
-                Ok(Instrument::FloatingRateInstrument(instrument))
+                Ok(Self::FloatingRateInstrument(instrument))
             }
             _ => Err(AtlasError::NotImplementedErr("RateType".to_string())),
         }

--- a/src/instruments/makedoublerateinstrument.rs
+++ b/src/instruments/makedoublerateinstrument.rs
@@ -64,7 +64,7 @@ impl MakeDoubleRateInstrument {
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn new() -> Self {
-        MakeDoubleRateInstrument {
+        Self {
             start_date: None,
             end_date: None,
             change_rate_date: None,
@@ -93,84 +93,84 @@ impl MakeDoubleRateInstrument {
 
     /// Sets the issue date.
     #[must_use]
-    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeDoubleRateInstrument {
+    pub const fn with_issue_date(mut self, issue_date: Date) -> Self {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
     #[must_use]
-    pub const fn with_first_coupon_date(mut self, first_coupon_date: Date) -> MakeDoubleRateInstrument {
+    pub const fn with_first_coupon_date(mut self, first_coupon_date: Date) -> Self {
         self.first_coupon_date = Some(first_coupon_date);
         self
     }
 
     /// Sets the currency.
     #[must_use]
-    pub const fn with_currency(mut self, currency: Currency) -> MakeDoubleRateInstrument {
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
     #[must_use]
-    pub const fn with_side(mut self, side: Side) -> MakeDoubleRateInstrument {
+    pub const fn with_side(mut self, side: Side) -> Self {
         self.side = Some(side);
         self
     }
 
     /// Sets the notional.
     #[must_use]
-    pub const fn with_notional(mut self, notional: f64) -> MakeDoubleRateInstrument {
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the instrument identifier.
     #[must_use]
-    pub fn with_id(mut self, id: String) -> MakeDoubleRateInstrument {
+    pub fn with_id(mut self, id: String) -> Self {
         self.id = Some(id);
         self
     }
 
     /// Sets the start date.
     #[must_use]
-    pub const fn with_start_date(mut self, start_date: Date) -> MakeDoubleRateInstrument {
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
     #[must_use]
-    pub const fn with_end_date(mut self, end_date: Date) -> MakeDoubleRateInstrument {
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the discount curve id.
     #[must_use]
-    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> Self {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the forecast curve id.
     #[must_use]
-    pub const fn with_forecast_curve_id(mut self, id: Option<usize>) -> MakeDoubleRateInstrument {
+    pub const fn with_forecast_curve_id(mut self, id: Option<usize>) -> Self {
         self.forecast_curve_id = id;
         self
     }
 
     /// Sets the tenor.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeDoubleRateInstrument {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the change rate date.
     #[must_use]
-    pub const fn with_tenor_change_rate(mut self, tenor_change_rate: Period) -> MakeDoubleRateInstrument {
+    pub const fn with_tenor_change_rate(mut self, tenor_change_rate: Period) -> Self {
         self.tenor_change_rate = Some(tenor_change_rate);
         self
     }
@@ -180,21 +180,21 @@ impl MakeDoubleRateInstrument {
     pub const fn with_tenor_grace_period(
         mut self,
         tenor_grace_period: Period,
-    ) -> MakeDoubleRateInstrument {
+    ) -> Self {
         self.tenor_grace_period = Some(tenor_grace_period);
         self
     }
 
     /// Sets the payment frequency.
     #[must_use]
-    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeDoubleRateInstrument {
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the change rate date.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Calendar) -> MakeDoubleRateInstrument {
+    pub fn with_calendar(mut self, calendar: Calendar) -> Self {
         self.calendar = Some(calendar);
         self
     }
@@ -204,7 +204,7 @@ impl MakeDoubleRateInstrument {
     pub const fn with_business_day_convention(
         mut self,
         business_day_convention: BusinessDayConvention,
-    ) -> MakeDoubleRateInstrument {
+    ) -> Self {
         self.business_day_convention = Some(business_day_convention);
         self
     }
@@ -214,14 +214,14 @@ impl MakeDoubleRateInstrument {
     pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: DateGenerationRule,
-    ) -> MakeDoubleRateInstrument {
+    ) -> Self {
         self.date_generation_rule = Some(date_generation_rule);
         self
     }
 
     /// Sets the rate type.
     #[must_use]
-    pub const fn with_rate_type(mut self, rate_type: RateType) -> MakeDoubleRateInstrument {
+    pub const fn with_rate_type(mut self, rate_type: RateType) -> Self {
         self.rate_type = Some(rate_type);
         self
     }
@@ -231,14 +231,14 @@ impl MakeDoubleRateInstrument {
     pub const fn with_first_part_rate_definition(
         mut self,
         rate_definition: RateDefinition,
-    ) -> MakeDoubleRateInstrument {
+    ) -> Self {
         self.first_part_rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the rate value for the first part.
     #[must_use]
-    pub const fn with_first_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
+    pub const fn with_first_part_rate(mut self, rate: f64) -> Self {
         self.first_part_rate = Some(rate);
         self
     }
@@ -248,14 +248,14 @@ impl MakeDoubleRateInstrument {
     pub const fn with_second_part_rate_definition(
         mut self,
         rate_definition: RateDefinition,
-    ) -> MakeDoubleRateInstrument {
+    ) -> Self {
         self.second_part_rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the rate value for the second part.
     #[must_use]
-    pub const fn with_second_part_rate(mut self, rate: f64) -> MakeDoubleRateInstrument {
+    pub const fn with_second_part_rate(mut self, rate: f64) -> Self {
         self.second_part_rate = Some(rate);
         self
     }

--- a/src/instruments/makefixedrateinstrument.rs
+++ b/src/instruments/makefixedrateinstrument.rs
@@ -66,8 +66,8 @@ impl MakeFixedRateInstrument {
     /// Creates a new MakeFixedRateInstrument builder with default values.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new() -> MakeFixedRateInstrument {
-        MakeFixedRateInstrument {
+    pub fn new() -> Self {
+        Self {
             start_date: None,
             end_date: None,
             first_coupon_date: None,
@@ -95,7 +95,7 @@ impl MakeFixedRateInstrument {
 
     /// Sets the issue date.
     #[must_use]
-    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateInstrument {
+    pub const fn with_issue_date(mut self, issue_date: Date) -> Self {
         self.issue_date = Some(issue_date);
         self
     }
@@ -105,21 +105,21 @@ impl MakeFixedRateInstrument {
     pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.first_coupon_date = first_coupon_date;
         self
     }
 
     /// Sets the currency.
     #[must_use]
-    pub const fn with_currency(mut self, currency: Currency) -> MakeFixedRateInstrument {
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
     #[must_use]
-    pub const fn with_side(mut self, side: Side) -> MakeFixedRateInstrument {
+    pub const fn with_side(mut self, side: Side) -> Self {
         self.side = Some(side);
         self
     }
@@ -129,28 +129,28 @@ impl MakeFixedRateInstrument {
     /// ### Details
     /// Currently does not handle negative amounts.
     #[must_use]
-    pub const fn with_notional(mut self, notional: f64) -> MakeFixedRateInstrument {
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the instrument id.
     #[must_use]
-    pub fn with_id(mut self, id: Option<String>) -> MakeFixedRateInstrument {
+    pub fn with_id(mut self, id: Option<String>) -> Self {
         self.id = id;
         self
     }
 
     /// Sets the yield rate.
     #[must_use]
-    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateInstrument {
+    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> Self {
         self.yield_rate = Some(yield_rate);
         self
     }
 
     /// Sets the calendar.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFixedRateInstrument {
+    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.calendar = calendar;
         self
     }
@@ -160,7 +160,7 @@ impl MakeFixedRateInstrument {
     pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.business_day_convention = business_day_convention;
         self
     }
@@ -170,7 +170,7 @@ impl MakeFixedRateInstrument {
     pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.date_generation_rule = date_generation_rule;
         self
     }
@@ -180,7 +180,7 @@ impl MakeFixedRateInstrument {
     pub const fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.rate_definition = Some(rate_definition);
         match self.rate_value {
             Some(rate_value) => {
@@ -207,7 +207,7 @@ impl MakeFixedRateInstrument {
 
     /// Sets the rate value.
     #[must_use]
-    pub const fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateInstrument {
+    pub const fn with_rate_value(mut self, rate_value: f64) -> Self {
         self.rate_value = Some(rate_value);
         match self.rate {
             Some(rate) => {
@@ -234,14 +234,14 @@ impl MakeFixedRateInstrument {
 
     /// Sets the start date.
     #[must_use]
-    pub const fn with_start_date(mut self, start_date: Date) -> MakeFixedRateInstrument {
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
     #[must_use]
-    pub const fn with_end_date(mut self, end_date: Date) -> MakeFixedRateInstrument {
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
@@ -251,14 +251,14 @@ impl MakeFixedRateInstrument {
     pub fn with_disbursements(
         mut self,
         disbursements: HashMap<Date, f64>,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.disbursements = Some(disbursements);
         self
     }
 
     /// Sets the redemptions.
     #[must_use]
-    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFixedRateInstrument {
+    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> Self {
         self.redemptions = Some(redemptions);
         self
     }
@@ -268,56 +268,56 @@ impl MakeFixedRateInstrument {
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
-    ) -> MakeFixedRateInstrument {
+    ) -> Self {
         self.additional_coupon_dates = Some(additional_coupon_dates);
         self
     }
 
     /// Sets the rate.
     #[must_use]
-    pub const fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateInstrument {
+    pub const fn with_rate(mut self, rate: InterestRate) -> Self {
         self.rate = Some(rate);
         self
     }
 
     /// Sets the discount curve id.
     #[must_use]
-    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateInstrument {
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> Self {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the tenor.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeFixedRateInstrument {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the payment frequency.
     #[must_use]
-    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateInstrument {
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure to bullet.
     #[must_use]
-    pub const fn bullet(mut self) -> MakeFixedRateInstrument {
+    pub const fn bullet(mut self) -> Self {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
     #[must_use]
-    pub const fn equal_redemptions(mut self) -> MakeFixedRateInstrument {
+    pub const fn equal_redemptions(mut self) -> Self {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
     #[must_use]
-    pub const fn zero(mut self) -> MakeFixedRateInstrument {
+    pub const fn zero(mut self) -> Self {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
@@ -325,14 +325,14 @@ impl MakeFixedRateInstrument {
 
     /// Sets the structure to equal payments.
     #[must_use]
-    pub const fn equal_payments(mut self) -> MakeFixedRateInstrument {
+    pub const fn equal_payments(mut self) -> Self {
         self.structure = Some(Structure::EqualPayments);
         self
     }
 
     /// Sets the structure to other.
     #[must_use]
-    pub const fn other(mut self) -> MakeFixedRateInstrument {
+    pub const fn other(mut self) -> Self {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
@@ -340,7 +340,7 @@ impl MakeFixedRateInstrument {
 
     /// Sets the structure.
     #[must_use]
-    pub const fn with_structure(mut self, structure: Structure) -> MakeFixedRateInstrument {
+    pub const fn with_structure(mut self, structure: Structure) -> Self {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makefixedrateleg.rs
+++ b/src/instruments/makefixedrateleg.rs
@@ -64,8 +64,8 @@ impl MakeFixedRateLeg {
     /// Creates a new MakeFixedRateLeg builder with default values.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new() -> MakeFixedRateLeg {
-        MakeFixedRateLeg {
+    pub fn new() -> Self {
+        Self {
             start_date: None,
             end_date: None,
             first_coupon_date: None,
@@ -93,35 +93,35 @@ impl MakeFixedRateLeg {
 
     /// Sets the end of month flag.
     #[must_use]
-    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFixedRateLeg {
+    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
         self.end_of_month = end_of_month;
         self
     }
 
     /// Sets the issue date.
     #[must_use]
-    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFixedRateLeg {
+    pub const fn with_issue_date(mut self, issue_date: Date) -> Self {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the first coupon date.
     #[must_use]
-    pub const fn with_first_coupon_date(mut self, first_coupon_date: Option<Date>) -> MakeFixedRateLeg {
+    pub const fn with_first_coupon_date(mut self, first_coupon_date: Option<Date>) -> Self {
         self.first_coupon_date = first_coupon_date;
         self
     }
 
     /// Sets the currency.
     #[must_use]
-    pub const fn with_currency(mut self, currency: Currency) -> MakeFixedRateLeg {
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the side.
     #[must_use]
-    pub const fn with_side(mut self, side: Side) -> MakeFixedRateLeg {
+    pub const fn with_side(mut self, side: Side) -> Self {
         self.side = Some(side);
         self
     }
@@ -131,21 +131,21 @@ impl MakeFixedRateLeg {
     /// ### Details
     /// Currently does not handle negative amounts.
     #[must_use]
-    pub const fn with_notional(mut self, notional: f64) -> MakeFixedRateLeg {
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the yield rate.
     #[must_use]
-    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> MakeFixedRateLeg {
+    pub const fn with_yield_rate(mut self, yield_rate: InterestRate) -> Self {
         self.yield_rate = Some(yield_rate);
         self
     }
 
     /// Sets the calendar.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFixedRateLeg {
+    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.calendar = calendar;
         self
     }
@@ -155,7 +155,7 @@ impl MakeFixedRateLeg {
     pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
-    ) -> MakeFixedRateLeg {
+    ) -> Self {
         self.business_day_convention = business_day_convention;
         self
     }
@@ -165,7 +165,7 @@ impl MakeFixedRateLeg {
     pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
-    ) -> MakeFixedRateLeg {
+    ) -> Self {
         self.date_generation_rule = date_generation_rule;
         self
     }
@@ -175,7 +175,7 @@ impl MakeFixedRateLeg {
     pub const fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
-    ) -> MakeFixedRateLeg {
+    ) -> Self {
         self.rate_definition = Some(rate_definition);
         match self.rate_value {
             Some(rate_value) => {
@@ -202,7 +202,7 @@ impl MakeFixedRateLeg {
 
     /// Sets the rate value.
     #[must_use]
-    pub const fn with_rate_value(mut self, rate_value: f64) -> MakeFixedRateLeg {
+    pub const fn with_rate_value(mut self, rate_value: f64) -> Self {
         self.rate_value = Some(rate_value);
         match self.rate {
             Some(rate) => {
@@ -229,28 +229,28 @@ impl MakeFixedRateLeg {
 
     /// Sets the start date.
     #[must_use]
-    pub const fn with_start_date(mut self, start_date: Date) -> MakeFixedRateLeg {
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
     #[must_use]
-    pub const fn with_end_date(mut self, end_date: Date) -> MakeFixedRateLeg {
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the disbursements.
     #[must_use]
-    pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> MakeFixedRateLeg {
+    pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> Self {
         self.disbursements = Some(disbursements);
         self
     }
 
     /// Sets the redemptions.
     #[must_use]
-    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFixedRateLeg {
+    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> Self {
         self.redemptions = Some(redemptions);
         self
     }
@@ -260,56 +260,56 @@ impl MakeFixedRateLeg {
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
-    ) -> MakeFixedRateLeg {
+    ) -> Self {
         self.additional_coupon_dates = Some(additional_coupon_dates);
         self
     }
 
     /// Sets the rate.
     #[must_use]
-    pub const fn with_rate(mut self, rate: InterestRate) -> MakeFixedRateLeg {
+    pub const fn with_rate(mut self, rate: InterestRate) -> Self {
         self.rate = Some(rate);
         self
     }
 
     /// Sets the discount curve id.
     #[must_use]
-    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> MakeFixedRateLeg {
+    pub const fn with_discount_curve_id(mut self, id: Option<usize>) -> Self {
         self.discount_curve_id = id;
         self
     }
 
     /// Sets the tenor.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeFixedRateLeg {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the payment frequency.
     #[must_use]
-    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFixedRateLeg {
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure to bullet.
     #[must_use]
-    pub const fn bullet(mut self) -> MakeFixedRateLeg {
+    pub const fn bullet(mut self) -> Self {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
     #[must_use]
-    pub const fn equal_redemptions(mut self) -> MakeFixedRateLeg {
+    pub const fn equal_redemptions(mut self) -> Self {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
     #[must_use]
-    pub const fn zero(mut self) -> MakeFixedRateLeg {
+    pub const fn zero(mut self) -> Self {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
@@ -317,14 +317,14 @@ impl MakeFixedRateLeg {
 
     /// Sets the structure to equal payments.
     #[must_use]
-    pub const fn equal_payments(mut self) -> MakeFixedRateLeg {
+    pub const fn equal_payments(mut self) -> Self {
         self.structure = Some(Structure::EqualPayments);
         self
     }
 
     /// Sets the structure to other.
     #[must_use]
-    pub const fn other(mut self) -> MakeFixedRateLeg {
+    pub const fn other(mut self) -> Self {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
@@ -332,7 +332,7 @@ impl MakeFixedRateLeg {
 
     /// Sets the structure.
     #[must_use]
-    pub const fn with_structure(mut self, structure: Structure) -> MakeFixedRateLeg {
+    pub const fn with_structure(mut self, structure: Structure) -> Self {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makefloatingrateinstrument.rs
+++ b/src/instruments/makefloatingrateinstrument.rs
@@ -59,8 +59,8 @@ impl MakeFloatingRateInstrument {
     /// Creates a new `MakeFloatingRateInstrument` with all fields initialized to `None`.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new() -> MakeFloatingRateInstrument {
-        MakeFloatingRateInstrument {
+    pub fn new() -> Self {
+        Self {
             start_date: None,
             end_date: None,
             first_coupon_date: None,
@@ -87,7 +87,7 @@ impl MakeFloatingRateInstrument {
 
     /// Sets the calendar for the instrument.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFloatingRateInstrument {
+    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.calendar = calendar;
         self
     }
@@ -97,7 +97,7 @@ impl MakeFloatingRateInstrument {
     pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.business_day_convention = business_day_convention;
         self
     }
@@ -107,21 +107,21 @@ impl MakeFloatingRateInstrument {
     pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.date_generation_rule = date_generation_rule;
         self
     }
 
     /// Sets the issue date for the instrument.
     #[must_use]
-    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateInstrument {
+    pub const fn with_issue_date(mut self, issue_date: Date) -> Self {
         self.issue_date = Some(issue_date);
         self
     }
 
     /// Sets the identifier for the instrument.
     #[must_use]
-    pub fn with_id(mut self, id: Option<String>) -> MakeFloatingRateInstrument {
+    pub fn with_id(mut self, id: Option<String>) -> Self {
         self.id = id;
         self
     }
@@ -131,28 +131,28 @@ impl MakeFloatingRateInstrument {
     pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.first_coupon_date = first_coupon_date;
         self
     }
 
     /// Sets the start date for the instrument.
     #[must_use]
-    pub const fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateInstrument {
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date for the instrument.
     #[must_use]
-    pub const fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateInstrument {
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the tenor for the instrument.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateInstrument {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = Some(tenor);
         self
     }
@@ -162,7 +162,7 @@ impl MakeFloatingRateInstrument {
     pub fn with_disbursements(
         mut self,
         disbursements: HashMap<Date, f64>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.disbursements = Some(disbursements);
         self
     }
@@ -172,7 +172,7 @@ impl MakeFloatingRateInstrument {
     pub fn with_redemptions(
         mut self,
         redemptions: HashMap<Date, f64>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.redemptions = Some(redemptions);
         self
     }
@@ -182,7 +182,7 @@ impl MakeFloatingRateInstrument {
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.additional_coupon_dates = Some(additional_coupon_dates);
         self
     }
@@ -192,7 +192,7 @@ impl MakeFloatingRateInstrument {
     pub const fn with_forecast_curve_id(
         mut self,
         forecast_curve_id: Option<usize>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.forecast_curve_id = forecast_curve_id;
         self
     }
@@ -202,7 +202,7 @@ impl MakeFloatingRateInstrument {
     pub const fn with_discount_curve_id(
         mut self,
         discount_curve_id: Option<usize>,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.discount_curve_id = discount_curve_id;
         self
     }
@@ -212,49 +212,49 @@ impl MakeFloatingRateInstrument {
     pub const fn with_rate_definition(
         mut self,
         rate_definition: RateDefinition,
-    ) -> MakeFloatingRateInstrument {
+    ) -> Self {
         self.rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the notional amount for the instrument.
     #[must_use]
-    pub const fn with_notional(mut self, notional: f64) -> MakeFloatingRateInstrument {
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the currency for the instrument.
     #[must_use]
-    pub const fn with_currency(mut self, currency: Currency) -> MakeFloatingRateInstrument {
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the spread for the floating rate instrument.
     #[must_use]
-    pub const fn with_spread(mut self, spread: f64) -> MakeFloatingRateInstrument {
+    pub const fn with_spread(mut self, spread: f64) -> Self {
         self.spread = Some(spread);
         self
     }
 
     /// Sets the instrument structure to bullet.
     #[must_use]
-    pub const fn bullet(mut self) -> MakeFloatingRateInstrument {
+    pub const fn bullet(mut self) -> Self {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the instrument structure to equal redemptions.
     #[must_use]
-    pub const fn equal_redemptions(mut self) -> MakeFloatingRateInstrument {
+    pub const fn equal_redemptions(mut self) -> Self {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the instrument structure to zero with single payment frequency.
     #[must_use]
-    pub const fn zero(mut self) -> MakeFloatingRateInstrument {
+    pub const fn zero(mut self) -> Self {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
@@ -262,7 +262,7 @@ impl MakeFloatingRateInstrument {
 
     /// Sets the instrument structure to other with custom frequency.
     #[must_use]
-    pub const fn other(mut self) -> MakeFloatingRateInstrument {
+    pub const fn other(mut self) -> Self {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
@@ -270,21 +270,21 @@ impl MakeFloatingRateInstrument {
 
     /// Sets the side (Receive or Pay) for the instrument.
     #[must_use]
-    pub const fn with_side(mut self, side: Side) -> MakeFloatingRateInstrument {
+    pub const fn with_side(mut self, side: Side) -> Self {
         self.side = Some(side);
         self
     }
 
     /// Sets the payment frequency for the instrument.
     #[must_use]
-    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateInstrument {
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure for the instrument.
     #[must_use]
-    pub const fn with_structure(mut self, structure: Structure) -> MakeFloatingRateInstrument {
+    pub const fn with_structure(mut self, structure: Structure) -> Self {
         self.structure = Some(structure);
         self
     }
@@ -794,7 +794,7 @@ impl From<FloatingRateInstrument> for MakeFloatingRateInstrument {
 }
 
 impl From<&FloatingRateInstrument> for MakeFloatingRateInstrument {
-    fn from(instrument: &FloatingRateInstrument) -> MakeFloatingRateInstrument {
+    fn from(instrument: &FloatingRateInstrument) -> Self {
         instrument.clone().into()
     }
 }

--- a/src/instruments/makefloatingrateleg.rs
+++ b/src/instruments/makefloatingrateleg.rs
@@ -57,8 +57,8 @@ impl MakeFloatingRateLeg {
     /// Creates a new `MakeFloatingRateLeg` builder with default values.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new() -> MakeFloatingRateLeg {
-        MakeFloatingRateLeg {
+    pub fn new() -> Self {
+        Self {
             start_date: None,
             end_date: None,
             first_coupon_date: None,
@@ -85,14 +85,14 @@ impl MakeFloatingRateLeg {
 
     /// Sets the end of month flag.
     #[must_use]
-    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> MakeFloatingRateLeg {
+    pub const fn with_end_of_month(mut self, end_of_month: Option<bool>) -> Self {
         self.end_of_month = end_of_month;
         self
     }
 
     /// Sets the calendar for business day adjustments.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> MakeFloatingRateLeg {
+    pub fn with_calendar(mut self, calendar: Option<Calendar>) -> Self {
         self.calendar = calendar;
         self
     }
@@ -102,7 +102,7 @@ impl MakeFloatingRateLeg {
     pub const fn with_business_day_convention(
         mut self,
         business_day_convention: Option<BusinessDayConvention>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.business_day_convention = business_day_convention;
         self
     }
@@ -112,14 +112,14 @@ impl MakeFloatingRateLeg {
     pub const fn with_date_generation_rule(
         mut self,
         date_generation_rule: Option<DateGenerationRule>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.date_generation_rule = date_generation_rule;
         self
     }
 
     /// Sets the issue date.
     #[must_use]
-    pub const fn with_issue_date(mut self, issue_date: Date) -> MakeFloatingRateLeg {
+    pub const fn with_issue_date(mut self, issue_date: Date) -> Self {
         self.issue_date = Some(issue_date);
         self
     }
@@ -129,42 +129,42 @@ impl MakeFloatingRateLeg {
     pub const fn with_first_coupon_date(
         mut self,
         first_coupon_date: Option<Date>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.first_coupon_date = first_coupon_date;
         self
     }
 
     /// Sets the start date.
     #[must_use]
-    pub const fn with_start_date(mut self, start_date: Date) -> MakeFloatingRateLeg {
+    pub const fn with_start_date(mut self, start_date: Date) -> Self {
         self.start_date = Some(start_date);
         self
     }
 
     /// Sets the end date.
     #[must_use]
-    pub const fn with_end_date(mut self, end_date: Date) -> MakeFloatingRateLeg {
+    pub const fn with_end_date(mut self, end_date: Date) -> Self {
         self.end_date = Some(end_date);
         self
     }
 
     /// Sets the tenor.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeFloatingRateLeg {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = Some(tenor);
         self
     }
 
     /// Sets the disbursement schedule.
     #[must_use]
-    pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> MakeFloatingRateLeg {
+    pub fn with_disbursements(mut self, disbursements: HashMap<Date, f64>) -> Self {
         self.disbursements = Some(disbursements);
         self
     }
 
     /// Sets the redemption schedule.
     #[must_use]
-    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> MakeFloatingRateLeg {
+    pub fn with_redemptions(mut self, redemptions: HashMap<Date, f64>) -> Self {
         self.redemptions = Some(redemptions);
         self
     }
@@ -174,7 +174,7 @@ impl MakeFloatingRateLeg {
     pub fn with_additional_coupon_dates(
         mut self,
         additional_coupon_dates: HashSet<Date>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.additional_coupon_dates = Some(additional_coupon_dates);
         self
     }
@@ -184,7 +184,7 @@ impl MakeFloatingRateLeg {
     pub const fn with_forecast_curve_id(
         mut self,
         forecast_curve_id: Option<usize>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.forecast_curve_id = forecast_curve_id;
         self
     }
@@ -194,56 +194,56 @@ impl MakeFloatingRateLeg {
     pub const fn with_discount_curve_id(
         mut self,
         discount_curve_id: Option<usize>,
-    ) -> MakeFloatingRateLeg {
+    ) -> Self {
         self.discount_curve_id = discount_curve_id;
         self
     }
 
     /// Sets the rate definition.
     #[must_use]
-    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> MakeFloatingRateLeg {
+    pub const fn with_rate_definition(mut self, rate_definition: RateDefinition) -> Self {
         self.rate_definition = Some(rate_definition);
         self
     }
 
     /// Sets the notional amount.
     #[must_use]
-    pub const fn with_notional(mut self, notional: f64) -> MakeFloatingRateLeg {
+    pub const fn with_notional(mut self, notional: f64) -> Self {
         self.notional = Some(notional);
         self
     }
 
     /// Sets the currency.
     #[must_use]
-    pub const fn with_currency(mut self, currency: Currency) -> MakeFloatingRateLeg {
+    pub const fn with_currency(mut self, currency: Currency) -> Self {
         self.currency = Some(currency);
         self
     }
 
     /// Sets the spread.
     #[must_use]
-    pub const fn with_spread(mut self, spread: f64) -> MakeFloatingRateLeg {
+    pub const fn with_spread(mut self, spread: f64) -> Self {
         self.spread = Some(spread);
         self
     }
 
     /// Sets the structure to bullet.
     #[must_use]
-    pub const fn bullet(mut self) -> MakeFloatingRateLeg {
+    pub const fn bullet(mut self) -> Self {
         self.structure = Some(Structure::Bullet);
         self
     }
 
     /// Sets the structure to equal redemptions.
     #[must_use]
-    pub const fn equal_redemptions(mut self) -> MakeFloatingRateLeg {
+    pub const fn equal_redemptions(mut self) -> Self {
         self.structure = Some(Structure::EqualRedemptions);
         self
     }
 
     /// Sets the structure to zero.
     #[must_use]
-    pub const fn zero(mut self) -> MakeFloatingRateLeg {
+    pub const fn zero(mut self) -> Self {
         self.structure = Some(Structure::Zero);
         self.payment_frequency = Some(Frequency::Once);
         self
@@ -251,7 +251,7 @@ impl MakeFloatingRateLeg {
 
     /// Sets the structure to other.
     #[must_use]
-    pub const fn other(mut self) -> MakeFloatingRateLeg {
+    pub const fn other(mut self) -> Self {
         self.structure = Some(Structure::Other);
         self.payment_frequency = Some(Frequency::OtherFrequency);
         self
@@ -259,21 +259,21 @@ impl MakeFloatingRateLeg {
 
     /// Sets the side of the transaction.
     #[must_use]
-    pub const fn with_side(mut self, side: Side) -> MakeFloatingRateLeg {
+    pub const fn with_side(mut self, side: Side) -> Self {
         self.side = Some(side);
         self
     }
 
     /// Sets the payment frequency.
     #[must_use]
-    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> MakeFloatingRateLeg {
+    pub const fn with_payment_frequency(mut self, frequency: Frequency) -> Self {
         self.payment_frequency = Some(frequency);
         self
     }
 
     /// Sets the structure.
     #[must_use]
-    pub const fn with_structure(mut self, structure: Structure) -> MakeFloatingRateLeg {
+    pub const fn with_structure(mut self, structure: Structure) -> Self {
         self.structure = Some(structure);
         self
     }

--- a/src/instruments/makeswap.rs
+++ b/src/instruments/makeswap.rs
@@ -67,7 +67,7 @@ impl MakeSwap {
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn new() -> Self {
-        MakeSwap {
+        Self {
             first_leg_rate_type: None,
             first_leg_rate_value: None,
             first_leg_rate_definition: None,

--- a/src/instruments/swap.rs
+++ b/src/instruments/swap.rs
@@ -14,7 +14,7 @@ impl Swap {
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn new(cashflows: Vec<Cashflow>, legs: Vec<Leg>, id: Option<String>) -> Self {
-        Swap {
+        Self {
             cashflows,
             legs,
             id,

--- a/src/instruments/traits.rs
+++ b/src/instruments/traits.rs
@@ -31,11 +31,11 @@ impl TryFrom<String> for Structure {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Bullet" => Ok(Structure::Bullet),
-            "EqualRedemptions" => Ok(Structure::EqualRedemptions),
-            "Zero" => Ok(Structure::Zero),
-            "EqualPayments" => Ok(Structure::EqualPayments),
-            "Other" => Ok(Structure::Other),
+            "Bullet" => Ok(Self::Bullet),
+            "EqualRedemptions" => Ok(Self::EqualRedemptions),
+            "Zero" => Ok(Self::Zero),
+            "EqualPayments" => Ok(Self::EqualPayments),
+            "Other" => Ok(Self::Other),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid structure: {}",
                 s
@@ -61,10 +61,10 @@ impl TryFrom<String> for CashflowType {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Redemption" => Ok(CashflowType::Redemption),
-            "Disbursement" => Ok(CashflowType::Disbursement),
-            "FixedRateCoupon" => Ok(CashflowType::FixedRateCoupon),
-            "FloatingRateCoupon" => Ok(CashflowType::FloatingRateCoupon),
+            "Redemption" => Ok(Self::Redemption),
+            "Disbursement" => Ok(Self::Disbursement),
+            "FixedRateCoupon" => Ok(Self::FixedRateCoupon),
+            "FloatingRateCoupon" => Ok(Self::FloatingRateCoupon),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid cashflow type: {}",
                 s

--- a/src/math/interpolation/enums.rs
+++ b/src/math/interpolation/enums.rs
@@ -28,10 +28,10 @@ impl Interpolator {
     #[must_use]
     pub fn interpolate(&self, x: f64, x_: &[f64], y_: &[f64], enable_extrapolation: bool) -> f64 {
         match self {
-            Interpolator::Linear => {
+            Self::Linear => {
                 LinearInterpolator::interpolate(x, x_, y_, enable_extrapolation)
             }
-            Interpolator::LogLinear => {
+            Self::LogLinear => {
                 LogLinearInterpolator::interpolate(x, x_, y_, enable_extrapolation)
             }
         }

--- a/src/models/simplemodel.rs
+++ b/src/models/simplemodel.rs
@@ -34,8 +34,8 @@ impl<'a> SimpleModel<'a> {
     /// A new `SimpleModel` instance with currency transformation disabled by default.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new(market_store: &'a MarketStore) -> SimpleModel<'a> {
-        SimpleModel {
+    pub fn new(market_store: &'a MarketStore) -> Self {
+        Self {
             market_store,
             transform_currencies: false,
         }
@@ -49,7 +49,7 @@ impl<'a> SimpleModel<'a> {
     /// # Returns
     /// The modified `SimpleModel` instance for method chaining.
     #[must_use]
-    pub const fn with_transform_currencies(mut self, flag: bool) -> SimpleModel<'a> {
+    pub const fn with_transform_currencies(mut self, flag: bool) -> Self {
         self.transform_currencies = flag;
         self
     }

--- a/src/rates/enums.rs
+++ b/src/rates/enums.rs
@@ -23,11 +23,11 @@ impl TryFrom<String> for Compounding {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Simple" => Ok(Compounding::Simple),
-            "Compounded" => Ok(Compounding::Compounded),
-            "Continuous" => Ok(Compounding::Continuous),
-            "SimpleThenCompounded" => Ok(Compounding::SimpleThenCompounded),
-            "CompoundedThenSimple" => Ok(Compounding::CompoundedThenSimple),
+            "Simple" => Ok(Self::Simple),
+            "Compounded" => Ok(Self::Compounded),
+            "Continuous" => Ok(Self::Continuous),
+            "SimpleThenCompounded" => Ok(Self::SimpleThenCompounded),
+            "CompoundedThenSimple" => Ok(Self::CompoundedThenSimple),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid compounding: {}",
                 s

--- a/src/rates/indexstore.rs
+++ b/src/rates/indexstore.rs
@@ -45,8 +45,8 @@ impl ReadIndex for Arc<RwLock<dyn InterestRateIndexTrait>> {
 impl IndexStore {
     /// Creates a new `IndexStore` with the given reference date.
     #[must_use]
-    pub fn new(reference_date: Date) -> IndexStore {
-        IndexStore {
+    pub fn new(reference_date: Date) -> Self {
+        Self {
             reference_date,
             index_map: HashMap::new(),
             currency_curve: HashMap::new(),

--- a/src/rates/interestrate.rs
+++ b/src/rates/interestrate.rs
@@ -31,8 +31,8 @@ impl RateDefinition {
         day_counter: DayCounter,
         compounding: Compounding,
         frequency: Frequency,
-    ) -> RateDefinition {
-        RateDefinition {
+    ) -> Self {
+        Self {
             day_counter,
             compounding,
             frequency,
@@ -60,7 +60,7 @@ impl RateDefinition {
 
 impl Default for RateDefinition {
     fn default() -> Self {
-        RateDefinition::new(
+        Self::new(
             DayCounter::Actual360,
             Compounding::Simple,
             Frequency::Annual,
@@ -94,8 +94,8 @@ impl InterestRate {
         compounding: Compounding,
         frequency: Frequency,
         day_counter: DayCounter,
-    ) -> InterestRate {
-        InterestRate {
+    ) -> Self {
+        Self {
             rate,
             rate_definition: RateDefinition::new(day_counter, compounding, frequency),
         }
@@ -103,8 +103,8 @@ impl InterestRate {
 
     /// Creates a new `InterestRate` from a rate value and a `RateDefinition`.
     #[must_use]
-    pub const fn from_rate_definition(rate: f64, rate_definition: RateDefinition) -> InterestRate {
-        InterestRate {
+    pub const fn from_rate_definition(rate: f64, rate_definition: RateDefinition) -> Self {
+        Self {
             rate,
             rate_definition,
         }
@@ -147,7 +147,7 @@ impl InterestRate {
         comp: Compounding,
         freq: Frequency,
         t: f64,
-    ) -> Result<InterestRate> {
+    ) -> Result<Self> {
         if compound <= 0.0 {
             return Err(AtlasError::InvalidValueErr(
                 "Positive compound factor required".to_string(),
@@ -188,7 +188,7 @@ impl InterestRate {
                 }
             }
         }
-        Ok(InterestRate::new(r, comp, freq, result_dc))
+        Ok(Self::new(r, comp, freq, result_dc))
     }
 
     /// Calculates the compound factor between two dates using the day counter.

--- a/src/rates/interestrateindex/iborindex.rs
+++ b/src/rates/interestrateindex/iborindex.rs
@@ -50,8 +50,8 @@ pub struct IborIndex {
 impl IborIndex {
     /// Creates a new IborIndex with the given reference date.
     #[must_use]
-    pub fn new(reference_date: Date) -> IborIndex {
-        IborIndex {
+    pub fn new(reference_date: Date) -> Self {
+        Self {
             name: None,
             reference_date,
             tenor: Period::empty(),

--- a/src/rates/interestrateindex/overnightcompoundedrateindex.rs
+++ b/src/rates/interestrateindex/overnightcompoundedrateindex.rs
@@ -99,8 +99,8 @@ pub fn compose_fixing_rate(
 impl OvernightCompoundedRateIndex {
     /// Creates a new `OvernightCompoundedRateIndex` with the given reference date.
     #[must_use]
-    pub fn new(reference_date: Date) -> OvernightCompoundedRateIndex {
-        OvernightCompoundedRateIndex {
+    pub fn new(reference_date: Date) -> Self {
+        Self {
             fixings_rates: HashMap::new(),
             overnight_index: OvernightIndex::new(reference_date),
         }

--- a/src/rates/interestrateindex/overnightindex.rs
+++ b/src/rates/interestrateindex/overnightindex.rs
@@ -39,8 +39,8 @@ pub struct OvernightIndex {
 impl OvernightIndex {
     /// Creates a new `OvernightIndex` with the given reference date.
     #[must_use]
-    pub fn new(reference_date: Date) -> OvernightIndex {
-        OvernightIndex {
+    pub fn new(reference_date: Date) -> Self {
+        Self {
             name: None,
             fixings: HashMap::new(),
             term_structure: None,

--- a/src/rates/yieldtermstructure/compositetermstructure.rs
+++ b/src/rates/yieldtermstructure/compositetermstructure.rs
@@ -50,8 +50,8 @@ impl CompositeTermStructure {
     pub fn new(
         spread_curve: Arc<dyn YieldTermStructureTrait>,
         base_curve: Arc<dyn YieldTermStructureTrait>,
-    ) -> CompositeTermStructure {
-        CompositeTermStructure {
+    ) -> Self {
+        Self {
             date_reference: base_curve.reference_date(),
             spread_curve,
             base_curve,
@@ -107,13 +107,13 @@ impl AdvanceTermStructureInTime for CompositeTermStructure {
     fn advance_to_date(&self, date: Date) -> Result<Arc<dyn YieldTermStructureTrait>> {
         let base = self.base_curve().advance_to_date(date)?;
         let spread = self.spread_curve().advance_to_date(date)?;
-        Ok(Arc::new(CompositeTermStructure::new(spread, base)))
+        Ok(Arc::new(Self::new(spread, base)))
     }
 
     fn advance_to_period(&self, period: Period) -> Result<Arc<dyn YieldTermStructureTrait>> {
         let base = self.base_curve().advance_to_period(period)?;
         let spread = self.spread_curve().advance_to_period(period)?;
-        Ok(Arc::new(CompositeTermStructure::new(spread, base)))
+        Ok(Arc::new(Self::new(spread, base)))
     }
 }
 

--- a/src/rates/yieldtermstructure/discounttermstructure.rs
+++ b/src/rates/yieldtermstructure/discounttermstructure.rs
@@ -89,7 +89,7 @@ impl DiscountTermStructure {
         day_counter: DayCounter,
         interpolator: Interpolator,
         enable_extrapolation: bool,
-    ) -> Result<DiscountTermStructure> {
+    ) -> Result<Self> {
         // check if year_fractions and discount_factors have the same size
         if dates.len() != discount_factors.len() {
             return Err(AtlasError::InvalidValueErr(
@@ -114,7 +114,7 @@ impl DiscountTermStructure {
             .map(|x| day_counter.year_fraction(reference_date, *x))
             .collect();
 
-        Ok(DiscountTermStructure {
+        Ok(Self {
             reference_date,
             dates,
             year_fractions,

--- a/src/rates/yieldtermstructure/flatforwardtermstructure.rs
+++ b/src/rates/yieldtermstructure/flatforwardtermstructure.rs
@@ -35,9 +35,9 @@ impl FlatForwardTermStructure {
         reference_date: Date,
         rate: f64,
         rate_definition: RateDefinition,
-    ) -> FlatForwardTermStructure {
+    ) -> Self {
         let rate = InterestRate::from_rate_definition(rate, rate_definition);
-        FlatForwardTermStructure {
+        Self {
             reference_date,
             rate,
         }
@@ -98,7 +98,7 @@ impl AdvanceTermStructureInTime for FlatForwardTermStructure {
         let new_reference_date = self
             .reference_date()
             .advance(period.length(), period.units());
-        Ok(Arc::new(FlatForwardTermStructure::new(
+        Ok(Arc::new(Self::new(
             new_reference_date,
             self.value(),
             self.rate_definition(),
@@ -106,7 +106,7 @@ impl AdvanceTermStructureInTime for FlatForwardTermStructure {
     }
 
     fn advance_to_date(&self, date: Date) -> Result<Arc<dyn YieldTermStructureTrait>> {
-        Ok(Arc::new(FlatForwardTermStructure::new(
+        Ok(Arc::new(Self::new(
             date,
             self.value(),
             self.rate_definition(),

--- a/src/rates/yieldtermstructure/tenorbasedzeroratetermstructure.rs
+++ b/src/rates/yieldtermstructure/tenorbasedzeroratetermstructure.rs
@@ -59,7 +59,7 @@ impl TenorBasedZeroRateTermStructure {
         rate_definition: RateDefinition,
         interpolation: Interpolator,
         enable_extrapolation: bool,
-    ) -> Result<TenorBasedZeroRateTermStructure> {
+    ) -> Result<Self> {
         let year_fractions = tenors
             .iter()
             .map(|x| {
@@ -70,7 +70,7 @@ impl TenorBasedZeroRateTermStructure {
             })
             .collect();
 
-        Ok(TenorBasedZeroRateTermStructure {
+        Ok(Self {
             reference_date,
             tenors,
             spreads,
@@ -146,7 +146,7 @@ impl YieldProvider for TenorBasedZeroRateTermStructure {
 impl AdvanceTermStructureInTime for TenorBasedZeroRateTermStructure {
     fn advance_to_period(&self, period: Period) -> Result<Arc<dyn YieldTermStructureTrait>> {
         let new_reference_date = self.reference_date + period;
-        Ok(Arc::new(TenorBasedZeroRateTermStructure::new(
+        Ok(Arc::new(Self::new(
             new_reference_date,
             self.tenors.clone(),
             self.spreads.clone(),

--- a/src/rates/yieldtermstructure/zeroratetermstructure.rs
+++ b/src/rates/yieldtermstructure/zeroratetermstructure.rs
@@ -73,7 +73,7 @@ impl ZeroRateTermStructure {
         rate_definition: RateDefinition,
         interpolator: Interpolator,
         enable_extrapolation: bool,
-    ) -> Result<ZeroRateTermStructure> {
+    ) -> Result<Self> {
         // check if dates and rates have the same size
         if dates.len() != rates.len() {
             return Err(AtlasError::InvalidValueErr(
@@ -97,7 +97,7 @@ impl ZeroRateTermStructure {
             })
             .collect();
 
-        Ok(ZeroRateTermStructure {
+        Ok(Self {
             reference_date,
             dates,
             year_fractions,
@@ -215,7 +215,7 @@ impl AdvanceTermStructureInTime for ZeroRateTermStructure {
             })
             .collect();
 
-        Ok(Arc::new(ZeroRateTermStructure::new(
+        Ok(Arc::new(Self::new(
             new_reference_date,
             new_dates,
             shifted_dfs?,

--- a/src/time/calendar.rs
+++ b/src/time/calendar.rs
@@ -45,12 +45,12 @@ impl Serialize for Calendar {
         S: serde::Serializer,
     {
         let s = match self {
-            Calendar::NullCalendar(cal) => cal.impl_name(),
-            Calendar::WeekendsOnly(cal) => cal.impl_name(),
-            Calendar::TARGET(cal) => cal.impl_name(),
-            Calendar::UnitedStates(cal) => cal.impl_name(),
-            Calendar::Brazil(cal) => cal.impl_name(),
-            Calendar::Chile(cal) => cal.impl_name(),
+            Self::NullCalendar(cal) => cal.impl_name(),
+            Self::WeekendsOnly(cal) => cal.impl_name(),
+            Self::TARGET(cal) => cal.impl_name(),
+            Self::UnitedStates(cal) => cal.impl_name(),
+            Self::Brazil(cal) => cal.impl_name(),
+            Self::Chile(cal) => cal.impl_name(),
         };
         serializer.serialize_str(&s)
     }
@@ -63,12 +63,12 @@ impl<'de> serde::Deserialize<'de> for Calendar {
     {
         let s = String::deserialize(deserializer)?;
         match s.as_str() {
-            "NullCalendar" => Ok(Calendar::NullCalendar(NullCalendar::new())),
-            "WeekendsOnly" => Ok(Calendar::WeekendsOnly(WeekendsOnly::new())),
-            "TARGET" => Ok(Calendar::TARGET(TARGET::new())),
-            "UnitedStates" => Ok(Calendar::UnitedStates(UnitedStates::default())),
-            "Brazil" => Ok(Calendar::Brazil(Brazil::default())),
-            "Chile" => Ok(Calendar::Chile(Chile::default())),
+            "NullCalendar" => Ok(Self::NullCalendar(NullCalendar::new())),
+            "WeekendsOnly" => Ok(Self::WeekendsOnly(WeekendsOnly::new())),
+            "TARGET" => Ok(Self::TARGET(TARGET::new())),
+            "UnitedStates" => Ok(Self::UnitedStates(UnitedStates::default())),
+            "Brazil" => Ok(Self::Brazil(Brazil::default())),
+            "Chile" => Ok(Self::Chile(Chile::default())),
             _ => Err(serde::de::Error::custom(format!("Invalid calendar: {}", s))),
         }
     }
@@ -79,12 +79,12 @@ impl TryFrom<String> for Calendar {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "NullCalendar" => Ok(Calendar::NullCalendar(NullCalendar::new())),
-            "WeekendsOnly" => Ok(Calendar::WeekendsOnly(WeekendsOnly::new())),
-            "TARGET" => Ok(Calendar::TARGET(TARGET::new())),
-            "UnitedStates" => Ok(Calendar::UnitedStates(UnitedStates::default())),
-            "Brazil" => Ok(Calendar::Brazil(Brazil::default())),
-            "Chile" => Ok(Calendar::Chile(Chile::default())),
+            "NullCalendar" => Ok(Self::NullCalendar(NullCalendar::new())),
+            "WeekendsOnly" => Ok(Self::WeekendsOnly(WeekendsOnly::new())),
+            "TARGET" => Ok(Self::TARGET(TARGET::new())),
+            "UnitedStates" => Ok(Self::UnitedStates(UnitedStates::default())),
+            "Brazil" => Ok(Self::Brazil(Brazil::default())),
+            "Chile" => Ok(Self::Chile(Chile::default())),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid calendar: {}",
                 s
@@ -109,89 +109,89 @@ impl From<Calendar> for String {
 impl ImplCalendar for Calendar {
     fn impl_name(&self) -> String {
         match self {
-            Calendar::NullCalendar(cal) => cal.impl_name(),
-            Calendar::WeekendsOnly(cal) => cal.impl_name(),
-            Calendar::TARGET(cal) => cal.impl_name(),
-            Calendar::UnitedStates(cal) => cal.impl_name(),
-            Calendar::Brazil(cal) => cal.impl_name(),
-            Calendar::Chile(cal) => cal.impl_name(),
+            Self::NullCalendar(cal) => cal.impl_name(),
+            Self::WeekendsOnly(cal) => cal.impl_name(),
+            Self::TARGET(cal) => cal.impl_name(),
+            Self::UnitedStates(cal) => cal.impl_name(),
+            Self::Brazil(cal) => cal.impl_name(),
+            Self::Chile(cal) => cal.impl_name(),
         }
     }
 
     fn impl_is_business_day(&self, date: &Date) -> bool {
         match self {
-            Calendar::NullCalendar(cal) => cal.impl_is_business_day(date),
-            Calendar::WeekendsOnly(cal) => cal.impl_is_business_day(date),
-            Calendar::TARGET(cal) => cal.impl_is_business_day(date),
-            Calendar::UnitedStates(cal) => cal.impl_is_business_day(date),
-            Calendar::Brazil(cal) => cal.impl_is_business_day(date),
-            Calendar::Chile(cal) => cal.impl_is_business_day(date),
+            Self::NullCalendar(cal) => cal.impl_is_business_day(date),
+            Self::WeekendsOnly(cal) => cal.impl_is_business_day(date),
+            Self::TARGET(cal) => cal.impl_is_business_day(date),
+            Self::UnitedStates(cal) => cal.impl_is_business_day(date),
+            Self::Brazil(cal) => cal.impl_is_business_day(date),
+            Self::Chile(cal) => cal.impl_is_business_day(date),
         }
     }
 
     fn added_holidays(&self) -> HashSet<Date> {
         match self {
-            Calendar::NullCalendar(cal) => cal.added_holidays(),
-            Calendar::WeekendsOnly(cal) => cal.added_holidays(),
-            Calendar::TARGET(cal) => cal.added_holidays(),
-            Calendar::UnitedStates(cal) => cal.added_holidays(),
-            Calendar::Brazil(cal) => cal.added_holidays(),
-            Calendar::Chile(cal) => cal.added_holidays(),
+            Self::NullCalendar(cal) => cal.added_holidays(),
+            Self::WeekendsOnly(cal) => cal.added_holidays(),
+            Self::TARGET(cal) => cal.added_holidays(),
+            Self::UnitedStates(cal) => cal.added_holidays(),
+            Self::Brazil(cal) => cal.added_holidays(),
+            Self::Chile(cal) => cal.added_holidays(),
         }
     }
 
     fn removed_holidays(&self) -> HashSet<Date> {
         match self {
-            Calendar::NullCalendar(cal) => cal.removed_holidays(),
-            Calendar::WeekendsOnly(cal) => cal.removed_holidays(),
-            Calendar::TARGET(cal) => cal.removed_holidays(),
-            Calendar::UnitedStates(cal) => cal.removed_holidays(),
-            Calendar::Brazil(cal) => cal.removed_holidays(),
-            Calendar::Chile(cal) => cal.removed_holidays(),
+            Self::NullCalendar(cal) => cal.removed_holidays(),
+            Self::WeekendsOnly(cal) => cal.removed_holidays(),
+            Self::TARGET(cal) => cal.removed_holidays(),
+            Self::UnitedStates(cal) => cal.removed_holidays(),
+            Self::Brazil(cal) => cal.removed_holidays(),
+            Self::Chile(cal) => cal.removed_holidays(),
         }
     }
 
     fn add_holiday(&mut self, date: Date) {
         match self {
-            Calendar::NullCalendar(cal) => cal.add_holiday(date),
-            Calendar::WeekendsOnly(cal) => cal.add_holiday(date),
-            Calendar::TARGET(cal) => cal.add_holiday(date),
-            Calendar::UnitedStates(cal) => cal.add_holiday(date),
-            Calendar::Brazil(cal) => cal.add_holiday(date),
-            Calendar::Chile(cal) => cal.add_holiday(date),
+            Self::NullCalendar(cal) => cal.add_holiday(date),
+            Self::WeekendsOnly(cal) => cal.add_holiday(date),
+            Self::TARGET(cal) => cal.add_holiday(date),
+            Self::UnitedStates(cal) => cal.add_holiday(date),
+            Self::Brazil(cal) => cal.add_holiday(date),
+            Self::Chile(cal) => cal.add_holiday(date),
         }
     }
 
     fn remove_holiday(&mut self, date: Date) {
         match self {
-            Calendar::NullCalendar(cal) => cal.remove_holiday(date),
-            Calendar::WeekendsOnly(cal) => cal.remove_holiday(date),
-            Calendar::TARGET(cal) => cal.remove_holiday(date),
-            Calendar::UnitedStates(cal) => cal.remove_holiday(date),
-            Calendar::Brazil(cal) => cal.remove_holiday(date),
-            Calendar::Chile(cal) => cal.remove_holiday(date),
+            Self::NullCalendar(cal) => cal.remove_holiday(date),
+            Self::WeekendsOnly(cal) => cal.remove_holiday(date),
+            Self::TARGET(cal) => cal.remove_holiday(date),
+            Self::UnitedStates(cal) => cal.remove_holiday(date),
+            Self::Brazil(cal) => cal.remove_holiday(date),
+            Self::Chile(cal) => cal.remove_holiday(date),
         }
     }
 
     fn holiday_list(&self, from: Date, to: Date, include_weekends: bool) -> Vec<Date> {
         match self {
-            Calendar::NullCalendar(cal) => cal.holiday_list(from, to, include_weekends),
-            Calendar::WeekendsOnly(cal) => cal.holiday_list(from, to, include_weekends),
-            Calendar::TARGET(cal) => cal.holiday_list(from, to, include_weekends),
-            Calendar::UnitedStates(cal) => cal.holiday_list(from, to, include_weekends),
-            Calendar::Brazil(cal) => cal.holiday_list(from, to, include_weekends),
-            Calendar::Chile(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::NullCalendar(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::WeekendsOnly(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::TARGET(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::UnitedStates(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::Brazil(cal) => cal.holiday_list(from, to, include_weekends),
+            Self::Chile(cal) => cal.holiday_list(from, to, include_weekends),
         }
     }
 
     fn business_day_list(&self, from: Date, to: Date) -> Vec<Date> {
         match self {
-            Calendar::NullCalendar(cal) => cal.business_day_list(from, to),
-            Calendar::WeekendsOnly(cal) => cal.business_day_list(from, to),
-            Calendar::TARGET(cal) => cal.business_day_list(from, to),
-            Calendar::UnitedStates(cal) => cal.business_day_list(from, to),
-            Calendar::Brazil(cal) => cal.business_day_list(from, to),
-            Calendar::Chile(cal) => cal.business_day_list(from, to),
+            Self::NullCalendar(cal) => cal.business_day_list(from, to),
+            Self::WeekendsOnly(cal) => cal.business_day_list(from, to),
+            Self::TARGET(cal) => cal.business_day_list(from, to),
+            Self::UnitedStates(cal) => cal.business_day_list(from, to),
+            Self::Brazil(cal) => cal.business_day_list(from, to),
+            Self::Chile(cal) => cal.business_day_list(from, to),
         }
     }
 }

--- a/src/time/calendars/brazil.rs
+++ b/src/time/calendars/brazil.rs
@@ -29,7 +29,7 @@ impl Brazil {
     /// Creates a new Brazil calendar with the specified market type.
     #[must_use]
     pub fn new(market: Market) -> Self {
-        Brazil {
+        Self {
             market,
             added_holidays: HashSet::new(),
             removed_holidays: HashSet::new(),

--- a/src/time/calendars/chile.rs
+++ b/src/time/calendars/chile.rs
@@ -130,7 +130,7 @@ impl Chile {
         let day = date.day();
         let month = date.month();
         let year = date.year();
-        if Chile::is_weekend(weekday) {
+        if Self::is_weekend(weekday) {
             return false;
         }
 

--- a/src/time/calendars/nullcalendar.rs
+++ b/src/time/calendars/nullcalendar.rs
@@ -16,7 +16,7 @@ impl NullCalendar {
     /// Creates a new instance of `NullCalendar`.
     #[must_use]
     pub fn new() -> Self {
-        NullCalendar {
+        Self {
             added_holidays: HashSet::new(),
             removed_holidays: HashSet::new(),
         }

--- a/src/time/calendars/unitedstates.rs
+++ b/src/time/calendars/unitedstates.rs
@@ -180,6 +180,6 @@ impl IsCalendar for UnitedStates {}
 
 impl Default for UnitedStates {
     fn default() -> Self {
-        UnitedStates::new(Market::Sofr)
+        Self::new(Market::Sofr)
     }
 }

--- a/src/time/calendars/weekendsonly.rs
+++ b/src/time/calendars/weekendsonly.rs
@@ -15,7 +15,7 @@ impl WeekendsOnly {
     /// Creates a new `WeekendsOnly` calendar instance.
     #[must_use]
     pub fn new() -> Self {
-        WeekendsOnly {
+        Self {
             added_holidays: HashSet::new(),
             removed_holidays: HashSet::new(),
         }

--- a/src/time/date.rs
+++ b/src/time/date.rs
@@ -168,7 +168,7 @@ pub struct Date {
 
 impl From<NaiveDate> for Date {
     fn from(base_date: NaiveDate) -> Self {
-        Date { base_date }
+        Self { base_date }
     }
 }
 
@@ -187,7 +187,7 @@ impl<'de> Deserialize<'de> for Date {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Date::from_str(&s, "%Y-%m-%d").map_err(serde::de::Error::custom)
+        Self::from_str(&s, "%Y-%m-%d").map_err(serde::de::Error::custom)
     }
 }
 
@@ -197,7 +197,7 @@ impl Date {
     pub fn new(year: i32, month: u32, day: u32) -> Date {
         let base_date = NaiveDate::from_ymd_opt(year, month, day);
         match base_date {
-            Some(base_date) => Date::from(base_date),
+            Some(base_date) => Self::from(base_date),
             None => panic!("Invalid date: {}-{}-{}", year, month, day),
         }
     }
@@ -209,7 +209,7 @@ impl Date {
     /// using the specified format.
     pub fn from_str(date: &str, fmt: &str) -> Result<Date> {
         let base_date = NaiveDate::parse_from_str(date, fmt)?;
-        Ok(Date::from(base_date))
+        Ok(Self::from(base_date))
     }
 
     /// Formats this date as a string using the specified format.
@@ -270,32 +270,32 @@ impl Date {
     #[must_use]
     pub fn advance(&self, n: i32, units: TimeUnit) -> Date {
         let base_date = self.base_date.advance(n, units);
-        Date::from(base_date)
+        Self::from(base_date)
     }
 
     /// Adds a `Period` to this date.
     #[must_use]
     pub fn add_period(&self, period: Period) -> Date {
         let base_date = self.base_date + period;
-        Date::from(base_date)
+        Self::from(base_date)
     }
 
     /// Returns the last day of the month for the given date.
     #[must_use]
     pub fn end_of_month(date: Date) -> Date {
         let base_date = NaiveDate::end_of_month(date.base_date);
-        Date::from(base_date)
+        Self::from(base_date)
     }
 
     /// Returns the nth occurrence of the specified weekday in the given month and year.
     #[must_use]
     pub fn nth_weekday(n: i32, day_of_week: Weekday, month: u32, year: i32) -> Date {
-        let base_date = Date::new(year, month, 1);
+        let base_date = Self::new(year, month, 1);
         let first = base_date.weekday();
         let skip = n - if day_of_week >= first { 1 } else { 0 };
         let day = 1 + day_of_week + skip * 7 - first;
         let base_date = NaiveDate::from_ymd_opt(year, month, day as u32).unwrap();
-        Date::from(base_date)
+        Self::from(base_date)
     }
 
     /// Returns the next occurrence of the specified weekday after the given date.
@@ -323,7 +323,7 @@ impl Date {
     #[must_use]
     pub fn empty() -> Date {
         //min
-        Date::from(NaiveDate::MIN)
+        Self::from(NaiveDate::MIN)
     }
 }
 

--- a/src/time/daycounter.rs
+++ b/src/time/daycounter.rs
@@ -32,12 +32,12 @@ impl DayCounter {
     #[must_use]
     pub fn day_count(&self, start: Date, end: Date) -> i64 {
         match self {
-            DayCounter::Actual360 => Actual360::day_count(start, end),
-            DayCounter::Actual365 => Actual365::day_count(start, end),
-            DayCounter::Thirty360 => Thirty360::day_count(start, end),
-            DayCounter::Thirty360US => Thirty360US::day_count(start, end),
-            DayCounter::ActualActual => ActualActual::day_count(start, end),
-            DayCounter::Business252 => Business252::day_count(start, end),
+            Self::Actual360 => Actual360::day_count(start, end),
+            Self::Actual365 => Actual365::day_count(start, end),
+            Self::Thirty360 => Thirty360::day_count(start, end),
+            Self::Thirty360US => Thirty360US::day_count(start, end),
+            Self::ActualActual => ActualActual::day_count(start, end),
+            Self::Business252 => Business252::day_count(start, end),
         }
     }
 
@@ -45,12 +45,12 @@ impl DayCounter {
     #[must_use]
     pub fn year_fraction(&self, start: Date, end: Date) -> f64 {
         match self {
-            DayCounter::Actual360 => Actual360::year_fraction(start, end),
-            DayCounter::Actual365 => Actual365::year_fraction(start, end),
-            DayCounter::Thirty360 => Thirty360::year_fraction(start, end),
-            DayCounter::Thirty360US => Thirty360US::year_fraction(start, end),
-            DayCounter::ActualActual => ActualActual::year_fraction(start, end),
-            DayCounter::Business252 => Business252::year_fraction(start, end),
+            Self::Actual360 => Actual360::year_fraction(start, end),
+            Self::Actual365 => Actual365::year_fraction(start, end),
+            Self::Thirty360 => Thirty360::year_fraction(start, end),
+            Self::Thirty360US => Thirty360US::year_fraction(start, end),
+            Self::ActualActual => ActualActual::year_fraction(start, end),
+            Self::Business252 => Business252::year_fraction(start, end),
         }
     }
 }
@@ -60,12 +60,12 @@ impl TryFrom<String> for DayCounter {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Actual360" => Ok(DayCounter::Actual360),
-            "Actual365" => Ok(DayCounter::Actual365),
-            "Thirty360" => Ok(DayCounter::Thirty360), // to match curveengine
-            "Thirty360US" => Ok(DayCounter::Thirty360US),
-            "ActualActual" => Ok(DayCounter::ActualActual),
-            "Business252" => Ok(DayCounter::Business252),
+            "Actual360" => Ok(Self::Actual360),
+            "Actual365" => Ok(Self::Actual365),
+            "Thirty360" => Ok(Self::Thirty360), // to match curveengine
+            "Thirty360US" => Ok(Self::Thirty360US),
+            "ActualActual" => Ok(Self::ActualActual),
+            "Business252" => Ok(Self::Business252),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid day counter: {}",
                 s

--- a/src/time/daycounters/actual360.rs
+++ b/src/time/daycounters/actual360.rs
@@ -25,6 +25,6 @@ impl DayCountProvider for Actual360 {
     }
 
     fn year_fraction(start: Date, end: Date) -> f64 {
-        Actual360::day_count(start, end) as f64 / 360.0
+        Self::day_count(start, end) as f64 / 360.0
     }
 }

--- a/src/time/daycounters/actual365.rs
+++ b/src/time/daycounters/actual365.rs
@@ -25,6 +25,6 @@ impl DayCountProvider for Actual365 {
     }
 
     fn year_fraction(start: Date, end: Date) -> f64 {
-        Actual365::day_count(start, end) as f64 / 365.0
+        Self::day_count(start, end) as f64 / 365.0
     }
 }

--- a/src/time/daycounters/actualactual.rs
+++ b/src/time/daycounters/actualactual.rs
@@ -34,7 +34,7 @@ impl DayCountProvider for ActualActual {
     }
 
     fn year_fraction(start: Date, end: Date) -> f64 {
-        let days = ActualActual::day_count(start, end);
+        let days = Self::day_count(start, end);
 
         let y1 = start.year();
         let y2 = end.year();

--- a/src/time/daycounters/thirty360.rs
+++ b/src/time/daycounters/thirty360.rs
@@ -33,7 +33,7 @@ impl DayCountProvider for Thirty360 {
     }
 
     fn year_fraction(start: Date, end: Date) -> f64 {
-        Thirty360::day_count(start, end) as f64 / 360.0
+        Self::day_count(start, end) as f64 / 360.0
     }
 }
 
@@ -91,6 +91,6 @@ impl DayCountProvider for Thirty360US {
     }
 
     fn year_fraction(start: Date, end: Date) -> f64 {
-        Thirty360US::day_count(start, end) as f64 / 360.0
+        Self::day_count(start, end) as f64 / 360.0
     }
 }

--- a/src/time/enums.rs
+++ b/src/time/enums.rs
@@ -44,19 +44,19 @@ impl TryFrom<String> for Frequency {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "NoFrequency" => Ok(Frequency::NoFrequency),
-            "Once" => Ok(Frequency::Once),
-            "Annual" => Ok(Frequency::Annual),
-            "Semiannual" => Ok(Frequency::Semiannual),
-            "EveryFourthMonth" => Ok(Frequency::EveryFourthMonth),
-            "Quarterly" => Ok(Frequency::Quarterly),
-            "Bimonthly" => Ok(Frequency::Bimonthly),
-            "Monthly" => Ok(Frequency::Monthly),
-            "EveryFourthWeek" => Ok(Frequency::EveryFourthWeek),
-            "Biweekly" => Ok(Frequency::Biweekly),
-            "Weekly" => Ok(Frequency::Weekly),
-            "Daily" => Ok(Frequency::Daily),
-            "OtherFrequency" => Ok(Frequency::OtherFrequency),
+            "NoFrequency" => Ok(Self::NoFrequency),
+            "Once" => Ok(Self::Once),
+            "Annual" => Ok(Self::Annual),
+            "Semiannual" => Ok(Self::Semiannual),
+            "EveryFourthMonth" => Ok(Self::EveryFourthMonth),
+            "Quarterly" => Ok(Self::Quarterly),
+            "Bimonthly" => Ok(Self::Bimonthly),
+            "Monthly" => Ok(Self::Monthly),
+            "EveryFourthWeek" => Ok(Self::EveryFourthWeek),
+            "Biweekly" => Ok(Self::Biweekly),
+            "Weekly" => Ok(Self::Weekly),
+            "Daily" => Ok(Self::Daily),
+            "OtherFrequency" => Ok(Self::OtherFrequency),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid frequency: {}",
                 s
@@ -104,10 +104,10 @@ impl TryFrom<String> for TimeUnit {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Days" => Ok(TimeUnit::Days),
-            "Weeks" => Ok(TimeUnit::Weeks),
-            "Months" => Ok(TimeUnit::Months),
-            "Years" => Ok(TimeUnit::Years),
+            "Days" => Ok(Self::Days),
+            "Weeks" => Ok(Self::Weeks),
+            "Months" => Ok(Self::Months),
+            "Years" => Ok(Self::Years),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid time unit: {}",
                 s
@@ -162,18 +162,18 @@ impl TryFrom<String> for Month {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "January" => Ok(Month::January),
-            "February" => Ok(Month::February),
-            "March" => Ok(Month::March),
-            "April" => Ok(Month::April),
-            "May" => Ok(Month::May),
-            "June" => Ok(Month::June),
-            "July" => Ok(Month::July),
-            "August" => Ok(Month::August),
-            "September" => Ok(Month::September),
-            "October" => Ok(Month::October),
-            "November" => Ok(Month::November),
-            "December" => Ok(Month::December),
+            "January" => Ok(Self::January),
+            "February" => Ok(Self::February),
+            "March" => Ok(Self::March),
+            "April" => Ok(Self::April),
+            "May" => Ok(Self::May),
+            "June" => Ok(Self::June),
+            "July" => Ok(Self::July),
+            "August" => Ok(Self::August),
+            "September" => Ok(Self::September),
+            "October" => Ok(Self::October),
+            "November" => Ok(Self::November),
+            "December" => Ok(Self::December),
             _ => Err(AtlasError::InvalidValueErr(format!("Invalid month: {}", s))),
         }
     }
@@ -259,16 +259,16 @@ impl TryFrom<String> for DateGenerationRule {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Backward" => Ok(DateGenerationRule::Backward),
-            "Forward" => Ok(DateGenerationRule::Forward),
-            "Zero" => Ok(DateGenerationRule::Zero),
-            "ThirdWednesday" => Ok(DateGenerationRule::ThirdWednesday),
-            "ThirdWednesdayInclusive" => Ok(DateGenerationRule::ThirdWednesdayInclusive),
-            "Twentieth" => Ok(DateGenerationRule::Twentieth),
-            "TwentiethIMM" => Ok(DateGenerationRule::TwentiethIMM),
-            "OldCDS" => Ok(DateGenerationRule::OldCDS),
-            "CDS" => Ok(DateGenerationRule::CDS),
-            "CDS2015" => Ok(DateGenerationRule::CDS2015),
+            "Backward" => Ok(Self::Backward),
+            "Forward" => Ok(Self::Forward),
+            "Zero" => Ok(Self::Zero),
+            "ThirdWednesday" => Ok(Self::ThirdWednesday),
+            "ThirdWednesdayInclusive" => Ok(Self::ThirdWednesdayInclusive),
+            "Twentieth" => Ok(Self::Twentieth),
+            "TwentiethIMM" => Ok(Self::TwentiethIMM),
+            "OldCDS" => Ok(Self::OldCDS),
+            "CDS" => Ok(Self::CDS),
+            "CDS2015" => Ok(Self::CDS2015),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid date generation rule: {}",
                 s
@@ -331,13 +331,13 @@ impl TryFrom<String> for BusinessDayConvention {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Following" => Ok(BusinessDayConvention::Following),
-            "ModifiedFollowing" => Ok(BusinessDayConvention::ModifiedFollowing),
-            "Preceding" => Ok(BusinessDayConvention::Preceding),
-            "ModifiedPreceding" => Ok(BusinessDayConvention::ModifiedPreceding),
-            "Unadjusted" => Ok(BusinessDayConvention::Unadjusted),
-            "HalfMonthModifiedFollowing" => Ok(BusinessDayConvention::HalfMonthModifiedFollowing),
-            "Nearest" => Ok(BusinessDayConvention::Nearest),
+            "Following" => Ok(Self::Following),
+            "ModifiedFollowing" => Ok(Self::ModifiedFollowing),
+            "Preceding" => Ok(Self::Preceding),
+            "ModifiedPreceding" => Ok(Self::ModifiedPreceding),
+            "Unadjusted" => Ok(Self::Unadjusted),
+            "HalfMonthModifiedFollowing" => Ok(Self::HalfMonthModifiedFollowing),
+            "Nearest" => Ok(Self::Nearest),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid business day convention: {}",
                 s
@@ -387,13 +387,13 @@ impl TryFrom<String> for Weekday {
 
     fn try_from(s: String) -> Result<Self> {
         match s.as_str() {
-            "Sunday" => Ok(Weekday::Sunday),
-            "Monday" => Ok(Weekday::Monday),
-            "Tuesday" => Ok(Weekday::Tuesday),
-            "Wednesday" => Ok(Weekday::Wednesday),
-            "Thursday" => Ok(Weekday::Thursday),
-            "Friday" => Ok(Weekday::Friday),
-            "Saturday" => Ok(Weekday::Saturday),
+            "Sunday" => Ok(Self::Sunday),
+            "Monday" => Ok(Self::Monday),
+            "Tuesday" => Ok(Self::Tuesday),
+            "Wednesday" => Ok(Self::Wednesday),
+            "Thursday" => Ok(Self::Thursday),
+            "Friday" => Ok(Self::Friday),
+            "Saturday" => Ok(Self::Saturday),
             _ => Err(AtlasError::InvalidValueErr(format!(
                 "Invalid weekday: {}",
                 s

--- a/src/time/imm.rs
+++ b/src/time/imm.rs
@@ -57,7 +57,7 @@ impl IMM {
     /// Panics if the date is not a valid IMM date
     #[must_use]
     pub fn code(imm_date: Date) -> String {
-        if !IMM::is_imm_date(imm_date, false) {
+        if !Self::is_imm_date(imm_date, false) {
             panic!("{} is not an IMM date", imm_date);
         }
         let y = imm_date.year() % 10;
@@ -119,9 +119,9 @@ impl IMM {
         let reference_year = reference_date.year() % 10;
         y += reference_date.year() - reference_year;
 
-        let result = IMM::next_date(Date::new(y, m, 1), false);
+        let result = Self::next_date(Date::new(y, m, 1), false);
         if result < reference_date {
-            return IMM::next_date(Date::new(y + 10, m, 1), false);
+            return Self::next_date(Date::new(y + 10, m, 1), false);
         }
         result
     }
@@ -155,7 +155,7 @@ impl IMM {
         }
         let result = Date::nth_weekday(3, Weekday::Wednesday, m, y);
         if result <= reference_date {
-            return IMM::next_date(Date::new(y, m, 22), main_cycle);
+            return Self::next_date(Date::new(y, m, 22), main_cycle);
         }
         result
     }
@@ -168,8 +168,8 @@ impl IMM {
     /// * `reference_date` - A reference date to resolve the code
     #[must_use]
     pub fn next_date_with_code(imm_code: String, main_cycle: bool, reference_date: Date) -> Date {
-        let imm_date = IMM::date(imm_code, reference_date);
-        IMM::next_date(imm_date + 1, main_cycle)
+        let imm_date = Self::date(imm_code, reference_date);
+        Self::next_date(imm_date + 1, main_cycle)
     }
 
     /// Returns the IMM code for the next IMM date after the given date.
@@ -179,8 +179,8 @@ impl IMM {
     /// * `main_cycle` - If true, only considers main cycle months
     #[must_use]
     pub fn next_code(d: Date, main_cycle: bool) -> String {
-        let next = IMM::next_date(d, main_cycle);
-        IMM::code(next)
+        let next = Self::next_date(d, main_cycle);
+        Self::code(next)
     }
 
     /// Returns the IMM code for the next IMM date after a given IMM code.
@@ -191,9 +191,9 @@ impl IMM {
     /// * `reference_date` - A reference date to resolve the code
     #[must_use]
     pub fn next_code_with_code(imm_code: String, main_cycle: bool, reference_date: Date) -> String {
-        let imm_date = IMM::date(imm_code, reference_date);
-        let next = IMM::next_date(imm_date, main_cycle);
-        IMM::code(next)
+        let imm_date = Self::date(imm_code, reference_date);
+        let next = Self::next_date(imm_date, main_cycle);
+        Self::code(next)
     }
 }
 

--- a/src/time/period.rs
+++ b/src/time/period.rs
@@ -41,8 +41,8 @@ impl Period {
     /// assert_eq!(p.units(), TimeUnit::Days);
     /// ```
     #[must_use]
-    pub const fn new(length: i32, units: TimeUnit) -> Period {
-        Period { length, units }
+    pub const fn new(length: i32, units: TimeUnit) -> Self {
+        Self { length, units }
     }
 
     /// Creates a Period from a Frequency.
@@ -62,7 +62,7 @@ impl Period {
     /// assert_eq!(p.units(), TimeUnit::Years);
     /// ```
     #[must_use]
-    pub const fn from_frequency(freq: Frequency) -> Option<Period> {
+    pub const fn from_frequency(freq: Frequency) -> Option<Self> {
         match freq {
             Frequency::NoFrequency => Some(Self {
                 units: TimeUnit::Days,
@@ -254,7 +254,7 @@ impl Period {
     ///
     /// # Errors
     /// Returns an error if the tenor string cannot be parsed into a valid `Period`.
-    pub fn from_str(tenor: &str) -> Result<Period> {
+    pub fn from_str(tenor: &str) -> Result<Self> {
         // parse multiple periods and add them
         let chars = tenor.chars();
         let mut periods = Vec::new();
@@ -268,14 +268,14 @@ impl Period {
                 current_period = String::new();
             }
         }
-        let mut result = Period::empty();
+        let mut result = Self::empty();
         for period in periods {
-            result = (result + Period::parse_single_period(&period)?)?;
+            result = (result + Self::parse_single_period(&period)?)?;
         }
         Ok(result)
     }
 
-    fn parse_single_period(tenor: &str) -> Result<Period> {
+    fn parse_single_period(tenor: &str) -> Result<Self> {
         let chars = tenor.chars();
         let mut length = String::new();
         let mut units = String::new();
@@ -302,7 +302,7 @@ impl Period {
                 ))
             }
         };
-        Ok(Period::new(length, units))
+        Ok(Self::new(length, units))
     }
 
     /// Returns the fraction of a year represented by this Period.
@@ -329,7 +329,7 @@ impl TryFrom<String> for Period {
     type Error = AtlasError;
 
     fn try_from(s: String) -> Result<Self> {
-        Period::from_str(&s)
+        Self::from_str(&s)
     }
 }
 
@@ -346,7 +346,7 @@ impl From<Period> for String {
 
 /// Deserializes a string in the format like 1Y or 1Y6M to a Period.
 impl<'de> serde::Deserialize<'de> for Period {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Period, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -100,8 +100,8 @@ impl Schedule {
         next_to_last_date: Date,
         dates: Vec<Date>,
         is_regular: Vec<bool>,
-    ) -> Schedule {
-        Schedule {
+    ) -> Self {
+        Self {
             tenor,
             calendar,
             convention,
@@ -117,8 +117,8 @@ impl Schedule {
 
     /// Creates an empty `Schedule` with default values.
     #[must_use]
-    pub fn empty() -> Schedule {
-        Schedule {
+    pub fn empty() -> Self {
+        Self {
             tenor: Period::empty(),
             calendar: Calendar::NullCalendar(NullCalendar::new()),
             convention: BusinessDayConvention::Unadjusted,
@@ -238,8 +238,8 @@ impl MakeSchedule {
     /// Returns a new instance of `MakeSchedule`.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
-    pub fn new(from: Date, to: Date) -> MakeSchedule {
-        MakeSchedule {
+    pub fn new(from: Date, to: Date) -> Self {
+        Self {
             effective_date: from,
             termination_date: to,
             tenor: Period::empty(),
@@ -257,14 +257,14 @@ impl MakeSchedule {
 
     /// Sets the tenor.
     #[must_use]
-    pub const fn with_tenor(mut self, tenor: Period) -> MakeSchedule {
+    pub const fn with_tenor(mut self, tenor: Period) -> Self {
         self.tenor = tenor;
         self
     }
 
     /// Sets the frequency.
     #[must_use]
-    pub fn with_frequency(mut self, frequency: Frequency) -> MakeSchedule {
+    pub fn with_frequency(mut self, frequency: Frequency) -> Self {
         self.tenor =
             Period::from_frequency(frequency).unwrap_or_else(|| panic!("Invalid frequency"));
         self
@@ -272,14 +272,14 @@ impl MakeSchedule {
 
     /// Sets the calendar.
     #[must_use]
-    pub fn with_calendar(mut self, calendar: Calendar) -> MakeSchedule {
+    pub fn with_calendar(mut self, calendar: Calendar) -> Self {
         self.calendar = calendar;
         self
     }
 
     /// Sets the convention. weekday correccions are applied.
     #[must_use]
-    pub const fn with_convention(mut self, convention: BusinessDayConvention) -> MakeSchedule {
+    pub const fn with_convention(mut self, convention: BusinessDayConvention) -> Self {
         self.convention = convention;
         self
     }
@@ -289,49 +289,49 @@ impl MakeSchedule {
     pub const fn with_termination_date_convention(
         mut self,
         termination_date_convention: BusinessDayConvention,
-    ) -> MakeSchedule {
+    ) -> Self {
         self.termination_date_convention = termination_date_convention;
         self
     }
 
     /// Sets the rule.
     #[must_use]
-    pub const fn with_rule(mut self, rule: DateGenerationRule) -> MakeSchedule {
+    pub const fn with_rule(mut self, rule: DateGenerationRule) -> Self {
         self.rule = rule;
         self
     }
 
     /// Sets the end of month flag.
     #[must_use]
-    pub const fn forwards(mut self) -> MakeSchedule {
+    pub const fn forwards(mut self) -> Self {
         self.rule = DateGenerationRule::Forward;
         self
     }
 
     /// Sets the date generation rule to backward.
     #[must_use]
-    pub const fn backwards(mut self) -> MakeSchedule {
+    pub const fn backwards(mut self) -> Self {
         self.rule = DateGenerationRule::Backward;
         self
     }
 
     /// Sets the end of month flag.
     #[must_use]
-    pub const fn end_of_month(mut self, flag: bool) -> MakeSchedule {
+    pub const fn end_of_month(mut self, flag: bool) -> Self {
         self.end_of_month = flag;
         self
     }
 
     /// Sets the first date.
     #[must_use]
-    pub const fn with_first_date(mut self, first_date: Date) -> MakeSchedule {
+    pub const fn with_first_date(mut self, first_date: Date) -> Self {
         self.first_date = first_date;
         self
     }
 
     /// Sets the next to last date.
     #[must_use]
-    pub const fn with_next_to_last_date(mut self, next_to_last_date: Date) -> MakeSchedule {
+    pub const fn with_next_to_last_date(mut self, next_to_last_date: Date) -> Self {
         self.next_to_last_date = next_to_last_date;
         self
     }


### PR DESCRIPTION
### Motivation
- A project-wide replacement introduced invalid uses of the keyword `Self` in places where concrete type names or explicit return types were required. 
- Builder structs and their `impl` blocks were accidentally renamed/retargeted causing compile errors and unresolved imports. 
- Some `Date`/`NaiveDate` APIs lost explicit type annotations which caused type inference and trait impl issues. 
- Restore correct types and signatures to ensure code compiles and behaviour remains consistent.

### Description
- Restored concrete builder/struct names and `impl` targets (`MakeFixedRateInstrument`, `MakeFloatingRateInstrument`, `MakeFixedRateLeg`, `MakeFloatingRateLeg`, `MakeDoubleRateInstrument`, `MakeSchedule`, etc.) and updated their methods to return `Self` where appropriate. 
- Replaced incorrect `impl ... for Self`/`impl Self` occurrences with the proper concrete types and corrected `From`/`Default` impl targets. 
- Fixed instrument construction sites (e.g. `LoanDepo`) to instantiate the correct types (`FixedRateInstrument`, `FloatingRateInstrument`) instead of invalid identifiers. 
- Reintroduced explicit `Date`/`NaiveDate` return types and adjusted associated `type Output` annotations where inference was too weak, and applied targeted `Self` -> `Self::Variant` enum improvements consistently across modules.

### Testing
- Ran `cargo test`; all unit tests passed (`202 passed; 0 failed`).
- Ran doc-tests; all doc-tests passed (`45 passed; 0 failed`).
- Verified the crate compiles successfully after fixes. 
- Committed the changes after confirming tests and compilation were green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637dc0ab6c832d88fa179a9ac8557d)