### PR TITLE
Resolve duplicate match arms

### DIFF
--- a/src/alm/rolloversimulationengine.rs
+++ b/src/alm/rolloversimulationengine.rs
@@ -242,13 +242,7 @@ mod tests {
             .map(|inst| {
                 let mut local_sum = 0.0;
                 inst.cashflows().iter().for_each(|cf| match cf {
-                    Cashflow::Disbursement(f) => {
-                        let payment_date = f.payment_date();
-                        if payment_date <= eval_date {
-                            local_sum += f.amount().unwrap() * f.side().sign();
-                        }
-                    }
-                    Cashflow::Redemption(f) => {
+                    Cashflow::Disbursement(f) | Cashflow::Redemption(f) => {
                         let payment_date = f.payment_date();
                         if payment_date <= eval_date {
                             local_sum += f.amount().unwrap() * f.side().sign();

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -279,8 +279,7 @@ impl Instrument {
     #[must_use]
     pub const fn second_rate_definition(&self) -> Option<RateDefinition> {
         match self {
-            Self::FixedRateInstrument(_) => None,
-            Self::FloatingRateInstrument(_) => None,
+            Self::FixedRateInstrument(_) | Self::FloatingRateInstrument(_) => None,
             Self::HybridRateInstrument(hri) => hri.second_rate_definition(),
             Self::DoubleRateInstrument(dri) => dri.second_rate_definition(),
         }

--- a/src/instruments/makedoublerateinstrument.rs
+++ b/src/instruments/makedoublerateinstrument.rs
@@ -283,16 +283,7 @@ impl MakeDoubleRateInstrument {
 
         // Definition of rate use to construct the redemption profile
         let rate = match rate_type {
-            RateType::FixedThenFixed => {
-                let rate_definition = self
-                    .first_part_rate_definition
-                    .ok_or(AtlasError::ValueNotSetErr("Rate definition".into()))?;
-                let rate_value = self
-                    .first_part_rate
-                    .ok_or(AtlasError::ValueNotSetErr("Rate value".into()))?;
-                InterestRate::from_rate_definition(rate_value, rate_definition)
-            }
-            RateType::FixedThenFloating => {
+            RateType::FixedThenFixed | RateType::FixedThenFloating => {
                 let rate_definition = self
                     .first_part_rate_definition
                     .ok_or(AtlasError::ValueNotSetErr("Rate definition".into()))?;
@@ -605,13 +596,7 @@ fn build_coupons_from_notionals(
         let d2 = date_pair[1];
 
         match rate_type {
-            RateType::FixedThenFixed => {
-                let rate =
-                    InterestRate::from_rate_definition(first_part_rate, first_part_rate_definition);
-                let coupon = FixedRateCoupon::new(*notional, rate, d1, d2, d2, currency, side);
-                cashflows.push(Cashflow::FixedRateCoupon(coupon));
-            }
-            RateType::FixedThenFloating => {
+            RateType::FixedThenFixed | RateType::FixedThenFloating => {
                 let rate =
                     InterestRate::from_rate_definition(first_part_rate, first_part_rate_definition);
                 let coupon = FixedRateCoupon::new(*notional, rate, d1, d2, d2, currency, side);
@@ -643,7 +628,7 @@ fn build_coupons_from_notionals(
         let d2 = date_pair[1];
 
         match rate_type {
-            RateType::FixedThenFixed => {
+            RateType::FixedThenFixed | RateType::FloatingThenFixed => {
                 let rate = InterestRate::from_rate_definition(
                     second_part_rate,
                     second_part_rate_definition,
@@ -664,14 +649,6 @@ fn build_coupons_from_notionals(
                     side,
                 );
                 cashflows.push(Cashflow::FloatingRateCoupon(coupon));
-            }
-            RateType::FloatingThenFixed => {
-                let rate = InterestRate::from_rate_definition(
-                    second_part_rate,
-                    second_part_rate_definition,
-                );
-                let coupon = FixedRateCoupon::new(*notional, rate, d1, d2, d2, currency, side);
-                cashflows.push(Cashflow::FixedRateCoupon(coupon));
             }
             _ => Err(AtlasError::NotImplementedErr("Rate type".into()))?,
         }

--- a/src/instruments/makefixedrateinstrument.rs
+++ b/src/instruments/makefixedrateinstrument.rs
@@ -1587,8 +1587,9 @@ mod tests_equal_payment {
             .for_each(|cf| println!("{}", cf));
 
         instrument.cashflows().iter().for_each(|cf| match &cf {
-            Cashflow::Disbursement(c) => assert!(c.amount().unwrap() > 0.0),
-            Cashflow::Redemption(c) => assert!(c.amount().unwrap() > 0.0),
+            Cashflow::Disbursement(c) | Cashflow::Redemption(c) => {
+                assert!(c.amount().unwrap() > 0.0)
+            }
             _ => (),
         });
 

--- a/src/math/interpolation/linear.rs
+++ b/src/math/interpolation/linear.rs
@@ -11,8 +11,7 @@ impl Interpolate for LinearInterpolator {
     fn interpolate(x: f64, x_: &[f64], y_: &[f64], enable_extrapolation: bool) -> f64 {
         let index =
             match x_.binary_search_by(|&probe| probe.partial_cmp(&x).unwrap_or(Ordering::Equal)) {
-                Ok(index) => index,
-                Err(index) => index,
+                Ok(index) | Err(index) => index,
             };
 
         if !enable_extrapolation && (x < *x_.first().unwrap() || x > *x_.last().unwrap()) {


### PR DESCRIPTION
### Motivation

- Fix Clippy `match_same_arms` findings where multiple `match` arms had identical bodies to remove redundancy.  
- Reduce duplicated code paths and make pattern handling clearer by merging equivalent patterns.  
- Preserve existing behavior while satisfying lint rules and improving readability.

### Description

- Merged identical match arms in `second_rate_definition` of `src/instruments/instrument.rs` by combining the `FixedRateInstrument` and `FloatingRateInstrument` cases.  
- Collapsed duplicate cashflow handling in `src/alm/rolloversimulationengine.rs` by combining `Cashflow::Disbursement` and `Cashflow::Redemption` arms.  
- Consolidated repeated `RateType` branches in `src/instruments/makedoublerateinstrument.rs` to reuse the same coupon construction logic.  
- Simplified test/misc cases by merging equivalent arms in `src/instruments/makefixedrateinstrument.rs` and replaced duplicate `Ok/Err` match arms in `src/math/interpolation/linear.rs`.

### Testing

- Ran the full test suite with `cargo test`.  
- Unit tests: `202 passed; 0 failed; 0 ignored` (all unit tests succeeded).  
- Doc-tests: `45 passed; 0 failed` (all doc-tests succeeded).  
- No runtime behavior changes were introduced; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963860a4760832d8c14e18fb8a3143f)