### PR TITLE
Inline format arguments to satisfy clippy

### DIFF
--- a/src/alm/npvengine.rs
+++ b/src/alm/npvengine.rs
@@ -81,9 +81,8 @@ impl<'a> NPVEngine<'a> {
                 chunk.iter_mut().try_for_each(|inst| {
                     fixing_visitor.visit(inst).map_err(|e| {
                         AtlasError::EvaluationErr(format!(
-                            "An error was found while processing instrument with id {:?}: {}",
-                            inst.id(),
-                            e
+                            "An error was found while processing instrument with id {id:?}: {e}",
+                            id = inst.id()
                         ))
                     })
                 })
@@ -103,9 +102,8 @@ impl<'a> NPVEngine<'a> {
                             .visit(inst)
                             .map_err(|e| {
                                 AtlasError::EvaluationErr(format!(
-                                "An error was found while processing instrument with id {:?}: {}",
-                                inst.id(),
-                                e
+                                "An error was found while processing instrument with id {id:?}: {e}",
+                                id = inst.id()
                             ))
                             })
                             .unwrap_or_else(|e| {

--- a/src/core/marketstore.rs
+++ b/src/core/marketstore.rs
@@ -134,14 +134,14 @@ impl MarketStore {
     pub fn advance_to_date(&self, date: Date) -> Result<Self> {
         if date < self.reference_date {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Date {date} is before reference date {}",
-                self.reference_date
+                "Date {date} is before reference date {reference_date}",
+                reference_date = self.reference_date
             )));
         }
         let days = i32::try_from(date - self.reference_date).map_err(|_| {
             AtlasError::InvalidValueErr(format!(
-                "Date {date} is too far from reference date {} to convert to days",
-                self.reference_date
+                "Date {date} is too far from reference date {reference_date} to convert to days",
+                reference_date = self.reference_date
             ))
         })?;
         let period = Period::new(days, TimeUnit::Days);

--- a/src/currencies/enums.rs
+++ b/src/currencies/enums.rs
@@ -179,8 +179,7 @@ impl TryFrom<&str> for Currency {
             "DKK" => Ok(Self::DKK),
             "IDR" => Ok(Self::IDR),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid currency: {}",
-                s
+                "Invalid currency: {s}"
             ))),
         }
     }

--- a/src/currencies/exchangeratestore.rs
+++ b/src/currencies/exchangeratestore.rs
@@ -106,8 +106,7 @@ impl ExchangeRateStore {
             }
         }
         Err(AtlasError::NotFoundErr(format!(
-            "No exchange rate found between {:?} and {:?}",
-            first_ccy, second_ccy
+            "No exchange rate found between {first_ccy:?} and {second_ccy:?}"
         )))
     }
 }

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -45,8 +45,7 @@ impl TryFrom<String> for RateType {
             "FixedThenFixed" => Ok(Self::FixedThenFixed),
             "Suffled" => Ok(Self::Suffled),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid rate type: {}",
-                s
+                "Invalid rate type: {s}"
             ))),
         }
     }

--- a/src/instruments/makeswap.rs
+++ b/src/instruments/makeswap.rs
@@ -575,8 +575,7 @@ impl MakeSwap {
                 }
             }
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "RateType: {:?}",
-                first_rate_type
+                "RateType: {first_rate_type:?}"
             )))?,
         };
 
@@ -759,8 +758,7 @@ impl MakeSwap {
                 }
             }
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "RateType: {:?}",
-                second_rate_type
+                "RateType: {second_rate_type:?}"
             )))?,
         };
 

--- a/src/instruments/traits.rs
+++ b/src/instruments/traits.rs
@@ -37,8 +37,7 @@ impl TryFrom<String> for Structure {
             "EqualPayments" => Ok(Self::EqualPayments),
             "Other" => Ok(Self::Other),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid structure: {}",
-                s
+                "Invalid structure: {s}"
             ))),
         }
     }
@@ -66,8 +65,7 @@ impl TryFrom<String> for CashflowType {
             "FixedRateCoupon" => Ok(Self::FixedRateCoupon),
             "FloatingRateCoupon" => Ok(Self::FloatingRateCoupon),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid cashflow type: {}",
-                s
+                "Invalid cashflow type: {s}"
             ))),
         }
     }

--- a/src/rates/enums.rs
+++ b/src/rates/enums.rs
@@ -29,8 +29,7 @@ impl TryFrom<String> for Compounding {
             "SimpleThenCompounded" => Ok(Self::SimpleThenCompounded),
             "CompoundedThenSimple" => Ok(Self::CompoundedThenSimple),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid compounding: {}",
-                s
+                "Invalid compounding: {s}"
             ))),
         }
     }

--- a/src/rates/indexstore.rs
+++ b/src/rates/indexstore.rs
@@ -73,8 +73,7 @@ impl IndexStore {
             .get(&currency)
             .cloned()
             .ok_or(AtlasError::NotFoundErr(format!(
-                "Currency curve for currency {:?}",
-                currency
+                "Currency curve for currency {currency:?}"
             )))
     }
 
@@ -90,8 +89,7 @@ impl IndexStore {
         self.index_map
             .get(&id)
             .ok_or(AtlasError::NotFoundErr(format!(
-                "Index with id {} not found",
-                id
+                "Index with id {id} not found"
             )))?
             .write()
             .map_err(|_| AtlasError::InvalidValueErr("Could not write index".to_string()))?
@@ -111,10 +109,10 @@ impl IndexStore {
         if self.reference_date != index.read_index()?.reference_date() {
             return Err(AtlasError::InvalidValueErr(
                 format!(
-                    "Index ({:?}) reference date ({}) does not match index store reference date ({})",
-                    index.read_index()?.name(),
-                    index.read_index()?.reference_date(),
-                    self.reference_date
+                    "Index ({name:?}) reference date ({reference_date}) does not match index store reference date ({store_reference_date})",
+                    name = index.read_index()?.name(),
+                    reference_date = index.read_index()?.reference_date(),
+                    store_reference_date = self.reference_date
                 )
                 .to_string(),
             ));
@@ -122,8 +120,7 @@ impl IndexStore {
         // check if name already exists
         if self.index_map.contains_key(&id) {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Index with id {} already exists",
-                id
+                "Index with id {id} already exists"
             )));
         }
 
@@ -144,10 +141,10 @@ impl IndexStore {
         if self.reference_date != index.read_index()?.reference_date() {
             return Err(AtlasError::InvalidValueErr(
                 format!(
-                    "Index ({:?}) reference date ({}) does not match index store reference date ({})",
-                    index.read_index()?.name(),
-                    index.read_index()?.reference_date(),
-                    self.reference_date
+                    "Index ({name:?}) reference date ({reference_date}) does not match index store reference date ({store_reference_date})",
+                    name = index.read_index()?.name(),
+                    reference_date = index.read_index()?.reference_date(),
+                    store_reference_date = self.reference_date
                 )
                 .to_string(),
             ));
@@ -155,8 +152,7 @@ impl IndexStore {
         // check if name already exists
         if !self.index_map.contains_key(&id) {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Index with id {} does not exist",
-                id
+                "Index with id {id} does not exist"
             )));
         }
 
@@ -174,8 +170,7 @@ impl IndexStore {
             .get(&id)
             .cloned()
             .ok_or(AtlasError::NotFoundErr(format!(
-                "Index with id {} not found",
-                id
+                "Index with id {id} not found"
             )))
     }
 
@@ -193,8 +188,7 @@ impl IndexStore {
             }
         }
         Err(AtlasError::NotFoundErr(format!(
-            "Index with name {} not found",
-            name
+            "Index with name {name} not found"
         )))
     }
 

--- a/src/rates/interestrateindex/iborindex.rs
+++ b/src/rates/interestrateindex/iborindex.rs
@@ -116,8 +116,8 @@ impl FixingProvider for IborIndex {
             .get(&date)
             .cloned()
             .ok_or(AtlasError::NotFoundErr(format!(
-                "No fixing for date {} for index {:?}",
-                date, self.name
+                "No fixing for date {date} for index {name:?}",
+                name = self.name
             )))
     }
 
@@ -167,8 +167,7 @@ impl YieldProvider for IborIndex {
     ) -> Result<f64> {
         if end_date < start_date {
             return Err(AtlasError::InvalidValueErr(format!(
-                "End date {:?} is before start date {:?}",
-                end_date, start_date
+                "End date {end_date:?} is before start date {start_date:?}"
             )));
         }
         if start_date < self.reference_date() {
@@ -231,9 +230,8 @@ impl AdvanceInterestRateIndexInTime for IborIndex {
         let days = (date - self.reference_date()) as i32;
         if days < 0 {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Date {} is before reference date {}",
-                date,
-                self.reference_date()
+                "Date {date} is before reference date {reference_date}",
+                reference_date = self.reference_date()
             )));
         }
         let period = Period::new(days, TimeUnit::Days);

--- a/src/rates/interestrateindex/overnightcompoundedrateindex.rs
+++ b/src/rates/interestrateindex/overnightcompoundedrateindex.rs
@@ -163,9 +163,8 @@ impl FixingProvider for OvernightCompoundedRateIndex {
             .get(&date)
             .cloned()
             .ok_or(AtlasError::NotFoundErr(format!(
-                "No fixing for date {} for index {:?}",
-                date,
-                self.overnight_index.name()
+                "No fixing for date {date} for index {name:?}",
+                name = self.overnight_index.name()
             )))
     }
 

--- a/src/rates/interestrateindex/overnightindex.rs
+++ b/src/rates/interestrateindex/overnightindex.rs
@@ -110,8 +110,8 @@ impl FixingProvider for OvernightIndex {
             .get(&date)
             .cloned()
             .ok_or(AtlasError::NotFoundErr(format!(
-                "No fixing for date {} for index {:?}",
-                date, self.name
+                "No fixing for date {date} for index {name:?}",
+                name = self.name
             )))
     }
 
@@ -188,8 +188,7 @@ impl YieldProvider for OvernightIndex {
                 .forward_rate(start_date, end_date, comp, freq)
         } else {
             Err(AtlasError::InvalidValueErr(format!(
-                "Invalid dates: start_date: {:?}, end_date: {:?}",
-                start_date, end_date
+                "Invalid dates: start_date: {start_date:?}, end_date: {end_date:?}"
             )))
         }
     }
@@ -218,8 +217,7 @@ impl AdvanceInterestRateIndexInTime for OvernightIndex {
             while seed < end_date {
                 let first_df = curve.discount_factor(seed)?;
                 let last_fixing = fixings.get(&seed).ok_or(AtlasError::NotFoundErr(format!(
-                    "No fixing for {} and date {}",
-                    name, seed
+                    "No fixing for {name} and date {seed}"
                 )))?;
                 seed = seed.advance(1, TimeUnit::Days);
                 let second_df = curve.discount_factor(seed)?;

--- a/src/rates/yieldtermstructure/flatforwardtermstructure.rs
+++ b/src/rates/yieldtermstructure/flatforwardtermstructure.rs
@@ -72,9 +72,8 @@ impl YieldProvider for FlatForwardTermStructure {
     fn discount_factor(&self, date: Date) -> Result<f64> {
         if date < self.reference_date() {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Date {:?} is before reference date {:?}",
-                date,
-                self.reference_date()
+                "Date {date:?} is before reference date {reference_date:?}",
+                reference_date = self.reference_date()
             )));
         }
         Ok(self.rate.discount_factor(self.reference_date(), date))

--- a/src/rates/yieldtermstructure/zeroratetermstructure.rs
+++ b/src/rates/yieldtermstructure/zeroratetermstructure.rs
@@ -229,9 +229,8 @@ impl AdvanceTermStructureInTime for ZeroRateTermStructure {
         let days = (date - self.reference_date()) as i32;
         if days < 0 {
             return Err(AtlasError::InvalidValueErr(format!(
-                "Date {:?} is before reference date {:?}",
-                date,
-                self.reference_date()
+                "Date {date:?} is before reference date {reference_date:?}",
+                reference_date = self.reference_date()
             )));
         }
         let period = Period::new(days, TimeUnit::Days);

--- a/src/time/calendar.rs
+++ b/src/time/calendar.rs
@@ -69,7 +69,7 @@ impl<'de> serde::Deserialize<'de> for Calendar {
             "UnitedStates" => Ok(Self::UnitedStates(UnitedStates::default())),
             "Brazil" => Ok(Self::Brazil(Brazil::default())),
             "Chile" => Ok(Self::Chile(Chile::default())),
-            _ => Err(serde::de::Error::custom(format!("Invalid calendar: {}", s))),
+            _ => Err(serde::de::Error::custom(format!("Invalid calendar: {s}"))),
         }
     }
 }
@@ -86,8 +86,7 @@ impl TryFrom<String> for Calendar {
             "Brazil" => Ok(Self::Brazil(Brazil::default())),
             "Chile" => Ok(Self::Chile(Chile::default())),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid calendar: {}",
-                s
+                "Invalid calendar: {s}"
             ))),
         }
     }

--- a/src/time/daycounter.rs
+++ b/src/time/daycounter.rs
@@ -67,8 +67,7 @@ impl TryFrom<String> for DayCounter {
             "ActualActual" => Ok(Self::ActualActual),
             "Business252" => Ok(Self::Business252),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid day counter: {}",
-                s
+                "Invalid day counter: {s}"
             ))),
         }
     }

--- a/src/time/enums.rs
+++ b/src/time/enums.rs
@@ -58,8 +58,7 @@ impl TryFrom<String> for Frequency {
             "Daily" => Ok(Self::Daily),
             "OtherFrequency" => Ok(Self::OtherFrequency),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid frequency: {}",
-                s
+                "Invalid frequency: {s}"
             ))),
         }
     }
@@ -109,8 +108,7 @@ impl TryFrom<String> for TimeUnit {
             "Months" => Ok(Self::Months),
             "Years" => Ok(Self::Years),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid time unit: {}",
-                s
+                "Invalid time unit: {s}"
             ))),
         }
     }
@@ -174,7 +172,7 @@ impl TryFrom<String> for Month {
             "October" => Ok(Self::October),
             "November" => Ok(Self::November),
             "December" => Ok(Self::December),
-            _ => Err(AtlasError::InvalidValueErr(format!("Invalid month: {}", s))),
+            _ => Err(AtlasError::InvalidValueErr(format!("Invalid month: {s}"))),
         }
     }
 }
@@ -270,8 +268,7 @@ impl TryFrom<String> for DateGenerationRule {
             "CDS" => Ok(Self::CDS),
             "CDS2015" => Ok(Self::CDS2015),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid date generation rule: {}",
-                s
+                "Invalid date generation rule: {s}"
             ))),
         }
     }
@@ -339,8 +336,7 @@ impl TryFrom<String> for BusinessDayConvention {
             "HalfMonthModifiedFollowing" => Ok(Self::HalfMonthModifiedFollowing),
             "Nearest" => Ok(Self::Nearest),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid business day convention: {}",
-                s
+                "Invalid business day convention: {s}"
             ))),
         }
     }
@@ -395,8 +391,7 @@ impl TryFrom<String> for Weekday {
             "Friday" => Ok(Self::Friday),
             "Saturday" => Ok(Self::Saturday),
             _ => Err(AtlasError::InvalidValueErr(format!(
-                "Invalid weekday: {}",
-                s
+                "Invalid weekday: {s}"
             ))),
         }
     }

--- a/src/time/imm.rs
+++ b/src/time/imm.rs
@@ -58,22 +58,22 @@ impl IMM {
     #[must_use]
     pub fn code(imm_date: Date) -> String {
         if !Self::is_imm_date(imm_date, false) {
-            panic!("{} is not an IMM date", imm_date);
+            panic!("{imm_date} is not an IMM date");
         }
         let y = imm_date.year() % 10;
         match imm_date.month() {
-            1 => format!("F{}", y),
-            2 => format!("G{}", y),
-            3 => format!("H{}", y),
-            4 => format!("J{}", y),
-            5 => format!("K{}", y),
-            6 => format!("M{}", y),
-            7 => format!("N{}", y),
-            8 => format!("Q{}", y),
-            9 => format!("U{}", y),
-            10 => format!("V{}", y),
-            11 => format!("X{}", y),
-            12 => format!("Z{}", y),
+            1 => format!("F{y}"),
+            2 => format!("G{y}"),
+            3 => format!("H{y}"),
+            4 => format!("J{y}"),
+            5 => format!("K{y}"),
+            6 => format!("M{y}"),
+            7 => format!("N{y}"),
+            8 => format!("Q{y}"),
+            9 => format!("U{y}"),
+            10 => format!("V{y}"),
+            11 => format!("X{y}"),
+            12 => format!("Z{y}"),
             _ => panic!("Invalid month number"),
         }
     }

--- a/src/time/period.rs
+++ b/src/time/period.rs
@@ -288,7 +288,7 @@ impl Period {
         }
         let length = length.parse::<i32>().map_err(|_| {
             AtlasError::PeriodOperationErr(
-                format!("Invalid period length ({})", length).to_string(),
+                format!("Invalid period length ({length})").to_string(),
             )
         })?;
         let units = match units.as_str() {
@@ -298,7 +298,7 @@ impl Period {
             "D" => TimeUnit::Days,
             _ => {
                 return Err(AtlasError::PeriodOperationErr(
-                    format!("Invalid time unit ({})", units).to_string(),
+                    format!("Invalid time unit ({units})").to_string(),
                 ))
             }
         };
@@ -496,7 +496,7 @@ impl Add for Period {
                     }
                     TimeUnit::Weeks | TimeUnit::Days => {
                         return Err(AtlasError::PeriodOperationErr(
-                            format!("impossible addition between {:?} and {:?}", result, other)
+                            format!("impossible addition between {result:?} and {other:?}")
                                 .to_string(),
                         ));
                     }
@@ -514,7 +514,7 @@ impl Add for Period {
                     }
                     TimeUnit::Weeks | TimeUnit::Days => {
                         return Err(AtlasError::PeriodOperationErr(
-                            format!("impossible addition between {:?} and {:?}", result, other)
+                            format!("impossible addition between {result:?} and {other:?}")
                                 .to_string(),
                         ));
                     }
@@ -533,7 +533,7 @@ impl Add for Period {
                     }
                     TimeUnit::Years | TimeUnit::Months => {
                         return Err(AtlasError::PeriodOperationErr(
-                            format!("impossible addition between {:?} and {:?}", result, other)
+                            format!("impossible addition between {result:?} and {other:?}")
                                 .to_string(),
                         ));
                     }
@@ -551,7 +551,7 @@ impl Add for Period {
                     }
                     TimeUnit::Years | TimeUnit::Months => {
                         return Err(AtlasError::PeriodOperationErr(
-                            format!("impossible addition between {:?} and {:?}", result, other)
+                            format!("impossible addition between {result:?} and {other:?}")
                                 .to_string(),
                         ));
                     }

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -348,8 +348,8 @@ impl MakeSchedule {
     pub fn build(&mut self) -> Result<Schedule> {
         if self.tenor.length() < 0 {
             return Err(AtlasError::MakeScheduleErr(format!(
-                "non positive tenor ({})",
-                self.tenor.length()
+                "non positive tenor ({tenor_length})",
+                tenor_length = self.tenor.length()
             )));
         }
         if self.tenor.length() == 0 {

--- a/src/visitors/cashflowaggregationvisitor.rs
+++ b/src/visitors/cashflowaggregationvisitor.rs
@@ -91,9 +91,8 @@ impl<T: HasCashflows> ConstVisit<T> for CashflowsAggregatorConstVisitor {
                 if let Some(currency) = self.validation_currency {
                     if cf.currency()? != currency {
                         return Err(AtlasError::InvalidValueErr(format!(
-                            "Cashflow currency {:?} does not match visitor currency {:?}",
-                            cf.currency()?,
-                            currency
+                            "Cashflow currency {cashflow_currency:?} does not match visitor currency {currency:?}",
+                            cashflow_currency = cf.currency()?
                         )));
                     }
                 }

--- a/src/visitors/cashflowcompressorconstvisitor.rs
+++ b/src/visitors/cashflowcompressorconstvisitor.rs
@@ -196,9 +196,9 @@ impl<T: HasCashflows> ConstVisit<T> for CashflowCompressorConstVisitor {
                 // validate that the cashflow currency is the same as the instrument currency
                 if cf.currency()? != self.currency {
                     return Err(AtlasError::InvalidValueErr(format!(
-                        "Cashflow currency {} does not match instrument currency {}",
-                        String::from(cf.currency()?),
-                        String::from(self.currency)
+                        "Cashflow currency {cashflow_currency} does not match instrument currency {instrument_currency}",
+                        cashflow_currency = String::from(cf.currency()?),
+                        instrument_currency = String::from(self.currency)
                     )));
                 }
 

--- a/src/visitors/durationconstvisitor.rs
+++ b/src/visitors/durationconstvisitor.rs
@@ -43,8 +43,7 @@ impl<'a, T: HasCashflows> ConstVisit<T> for DurationConstVisitor<'a> {
                     self.market_data
                         .get(id)
                         .ok_or(AtlasError::NotFoundErr(format!(
-                            "Market data for cashflow with id {}",
-                            id
+                            "Market data for cashflow with id {id}"
                         )))?;
 
                 if cf_market_data.reference_date() <= cf.payment_date() {

--- a/src/visitors/fixingvisitor.rs
+++ b/src/visitors/fixingvisitor.rs
@@ -40,8 +40,7 @@ impl<T: HasCashflows> Visit<T> for FixingVisitor<'_> {
                         self.market_data
                             .get(id)
                             .ok_or(AtlasError::NotFoundErr(format!(
-                                "Market data for cashflow with id {}",
-                                id
+                                "Market data for cashflow with id {id}"
                             )))?;
                     let fixing_rate = cf_market_data.fwd()?;
                     frcf.set_fixing_rate(fixing_rate);

--- a/src/visitors/npvbydateconstvisitor.rs
+++ b/src/visitors/npvbydateconstvisitor.rs
@@ -59,8 +59,7 @@ impl<T: HasCashflows> ConstVisit<T> for NPVByDateConstVisitor<'_> {
                     self.market_data
                         .get(id)
                         .ok_or(AtlasError::NotFoundErr(format!(
-                            "Market data for cashflow with id {}",
-                            id
+                            "Market data for cashflow with id {id}"
                         )))?;
 
                 if cf_market_data.reference_date() == cf.payment_date()

--- a/src/visitors/npvbytenorconstvisitor.rs
+++ b/src/visitors/npvbytenorconstvisitor.rs
@@ -71,8 +71,7 @@ impl<T: HasCashflows> ConstVisit<T> for NPVByTenorConstVisitor<'_> {
                     self.market_data
                         .get(id)
                         .ok_or(AtlasError::NotFoundErr(format!(
-                            "Market data for cashflow with id {}",
-                            id
+                            "Market data for cashflow with id {id}"
                         )))?;
 
                 if cf_market_data.reference_date() == cf.payment_date()

--- a/src/visitors/npvconstvisitor.rs
+++ b/src/visitors/npvconstvisitor.rs
@@ -44,8 +44,7 @@ impl<'a, T: HasCashflows> ConstVisit<T> for NPVConstVisitor<'a> {
                 self.market_data
                     .get(id)
                     .ok_or(AtlasError::NotFoundErr(format!(
-                        "Market data for cashflow with id {}",
-                        id
+                        "Market data for cashflow with id {id}"
                     )))?;
 
             if cf_market_data.reference_date() == cf.payment_date() && !self.include_today_cashflows

--- a/src/visitors/zspreadconstvisitor.rs
+++ b/src/visitors/zspreadconstvisitor.rs
@@ -59,8 +59,7 @@ where
             .market_data
             .get(id)
             .ok_or(AtlasError::NotFoundErr(format!(
-                "Market data for cashflow with id {}",
-                id
+                "Market data for cashflow with id {id}"
             )))?;
 
         let t = self


### PR DESCRIPTION
### Motivation
- Address Clippy warnings about "variables can be used directly in the `format!` string" to improve code style and lint compliance.
- Make error and diagnostic messages consistent by using captured/interpolated format arguments.
- Reduce trivial allocations and improve readability of formatted strings across the codebase.
- Ensure no behavioral changes while satisfying pedantic lint rules.

### Description
- Rewrote `format!` calls to use inline/captured variables (e.g. `format!("... {var} ...")`) across multiple modules including time, rates, instruments, visitors, currencies, and core market/index stores.
- Updated panic and error messages to use interpolated arguments (e.g. `panic!("{imm_date} is not an IMM date")`, `AtlasError::InvalidValueErr(format!("Date {date} is before reference date {reference_date}", reference_date = ...))`).
- Fixed various message patterns including debug formatting (`{var:?}`) and string conversions to follow the same approach.
- Changes touch many files (examples: `src/time/imm.rs`, `src/time/period.rs`, `src/time/enums.rs`, `src/rates/indexstore.rs`, `src/core/marketstore.rs`, visitor modules, index modules, etc.).

### Testing
- Ran `cargo test` which executed unit tests and doctests across the crate.
- All unit tests passed: 202 passed, 0 failed.
- All doc-tests passed: 45 passed, 0 failed.
- The change is limited to formatting of messages and did not alter any functional tests or behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639105aa10832d9ca6b4f987701b22)