### PR TITLE
Fix float comparisons flagged by clippy

### DIFF
--- a/src/instruments/makefloatingrateinstrument.rs
+++ b/src/instruments/makefloatingrateinstrument.rs
@@ -868,7 +868,7 @@ mod tests {
             .mut_cashflows()
             .iter_mut()
             .for_each(|cf| cf.set_fixing_rate(0.002));
-        assert_eq!(instrument.notional(), 100.0);
+        assert!((instrument.notional() - 100.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
 
@@ -900,7 +900,7 @@ mod tests {
             .mut_cashflows()
             .iter_mut()
             .for_each(|cf| cf.set_fixing_rate(0.002));
-        assert_eq!(instrument.notional(), 100.0);
+        assert!((instrument.notional() - 100.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
 
@@ -933,7 +933,7 @@ mod tests {
             .mut_cashflows()
             .iter_mut()
             .for_each(|cf| cf.set_fixing_rate(0.002));
-        assert_eq!(instrument.notional(), 100.0);
+        assert!((instrument.notional() - 100.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
 
@@ -965,7 +965,7 @@ mod tests {
             .mut_cashflows()
             .iter_mut()
             .for_each(|cf| cf.set_fixing_rate(0.002));
-        assert_eq!(instrument.notional(), 100.0);
+        assert!((instrument.notional() - 100.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
 
         Ok(())
@@ -1011,7 +1011,7 @@ mod tests {
             .mut_cashflows()
             .iter_mut()
             .for_each(|cf| cf.set_fixing_rate(0.002));
-        assert_eq!(instrument.notional(), 100.0);
+        assert!((instrument.notional() - 100.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
 
         Ok(())
@@ -1043,7 +1043,7 @@ mod tests {
         let builder = MakeFloatingRateInstrument::from(&instrument);
         let instrument2 = builder.build()?;
 
-        assert_eq!(instrument2.notional(), instrument.notional());
+        assert!((instrument2.notional() - instrument.notional()).abs() < 1e-12);
         assert_eq!(instrument2.start_date(), instrument.start_date());
         assert_eq!(instrument2.end_date(), instrument.end_date());
         assert_eq!(instrument2.rate_definition(), instrument.rate_definition());
@@ -1051,7 +1051,7 @@ mod tests {
             instrument2.payment_frequency(),
             instrument.payment_frequency()
         );
-        assert_eq!(instrument2.spread(), instrument.spread());
+        assert!((instrument2.spread() - instrument.spread()).abs() < 1e-12);
         assert_eq!(instrument2.side(), instrument.side());
         assert_eq!(instrument2.currency()?, instrument.currency()?);
         assert_eq!(

--- a/src/rates/interestrate.rs
+++ b/src/rates/interestrate.rs
@@ -155,7 +155,7 @@ impl InterestRate {
         }
         let r: f64;
         let f = f64::from(freq as i32);
-        if compound == 1.0 {
+        if (compound - 1.0).abs() < 1e-12 {
             if t < 0.0 {
                 return Err(AtlasError::InvalidValueErr(
                     "Non-negative time required".to_string(),
@@ -628,7 +628,7 @@ mod tests {
             Frequency::Annual,
             DayCounter::Actual360,
         );
-        assert_eq!(ir.rate(), 0.05);
+        assert!((ir.rate() - 0.05).abs() < 1e-12);
         assert_eq!(ir.compounding(), Compounding::Simple);
         assert_eq!(ir.frequency(), Frequency::Annual);
         assert_eq!(ir.day_counter(), DayCounter::Actual360);
@@ -642,7 +642,7 @@ mod tests {
             Frequency::Annual,
         );
         let ir = InterestRate::from_rate_definition(0.05, rd);
-        assert_eq!(ir.rate(), 0.05);
+        assert!((ir.rate() - 0.05).abs() < 1e-12);
         assert_eq!(ir.compounding(), Compounding::Simple);
         assert_eq!(ir.frequency(), Frequency::Annual);
         assert_eq!(ir.day_counter(), DayCounter::Actual360);

--- a/src/time/daycounter.rs
+++ b/src/time/daycounter.rs
@@ -192,7 +192,7 @@ mod tests {
 
         let yf_1 = DayCounter::Thirty360.year_fraction(start, end_1);
         let yf_2 = DayCounter::Thirty360.year_fraction(start, end_2);
-        assert_ne!(yf_1, yf_2);
+        assert!((yf_1 - yf_2).abs() > 1e-12);
     }
 
     #[test]

--- a/src/visitors/cashflowcompressorconstvisitor.rs
+++ b/src/visitors/cashflowcompressorconstvisitor.rs
@@ -414,7 +414,7 @@ mod tests {
         visitor.visit(&instrument_b)?;
 
         let instrument = visitor.as_instrument()?;
-        assert_eq!(instrument.notional(), 200.0);
+        assert!((instrument.notional() - 200.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
         assert_eq!(instrument.currency()?, Currency::USD);
@@ -465,7 +465,7 @@ mod tests {
         visitor.visit(&instrument_b)?;
 
         let instrument = visitor.as_instrument()?;
-        assert_eq!(instrument.notional(), 200.0);
+        assert!((instrument.notional() - 200.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
         assert_eq!(instrument.currency()?, Currency::USD);
@@ -518,7 +518,7 @@ mod tests {
         visitor.visit(&instrument_b)?;
 
         let instrument = visitor.as_instrument()?;
-        assert_eq!(instrument.notional(), 200.0);
+        assert!((instrument.notional() - 200.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
         assert_eq!(instrument.currency()?, Currency::USD);
@@ -570,7 +570,7 @@ mod tests {
         visitor.visit(&instrument_b)?;
 
         let instrument = visitor.as_instrument()?;
-        assert_eq!(instrument.notional(), 200.0);
+        assert!((instrument.notional() - 200.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
         assert_eq!(instrument.end_date(), end_date);
         assert_eq!(instrument.currency()?, Currency::USD);
@@ -629,7 +629,7 @@ mod tests {
         visitor.visit(&instrument_b)?;
 
         let instrument = visitor.as_instrument()?;
-        assert_eq!(instrument.notional(), 200.0);
+        assert!((instrument.notional() - 200.0).abs() < 1e-12);
         assert_eq!(instrument.start_date(), start_date);
 
         instrument.cashflows().iter().for_each(|cf| {

--- a/src/visitors/npvconstvisitor.rs
+++ b/src/visitors/npvconstvisitor.rs
@@ -300,7 +300,7 @@ mod tests {
         let npv_visitor = NPVConstVisitor::new(&data, true);
         let npv = npv_visitor.visit(&instrument)?;
 
-        assert_ne!(npv, 0.0);
+        assert!(npv.abs() > 1e-12);
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Clippy flagged many instances of strict float equality/inequality comparisons (`f32`/`f64`) which are unstable and error-prone.
- Tests and some logic relied on `assert_eq!`/`assert_ne!` with floats and direct `==` checks, triggering the `float_cmp` lint.
- The intent is to use epsilon-based comparisons for numerical stability and to satisfy clippy rules.
- Also ensure behavior in `implied_rate` checks treats near-1.0 compound factors as zero using a tolerance.

### Description
- Replaced strict float assertions with epsilon checks such as `assert!((a - b).abs() < 1e-12)` or `assert!(value.abs() > 1e-12)` in test modules.
- Updated `InterestRate::implied_rate` to use an epsilon check `if (compound - 1.0).abs() < 1e-12` instead of `compound == 1.0`.
- Files modified: `src/instruments/makefloatingrateinstrument.rs`, `src/rates/interestrate.rs`, `src/time/daycounter.rs`, `src/visitors/cashflowcompressorconstvisitor.rs`, and `src/visitors/npvconstvisitor.rs`.
- Kept comparisons' semantics by using small tolerances (`1e-12` or `1e-9` in existing tests) to avoid changing test intent.

### Testing
- Ran `cargo test`; unit tests completed successfully with `202 passed; 0 failed`.
- Ran doc-tests as part of `cargo test`; documentation tests completed successfully with `45 passed; 0 failed`.
- All modified tests that used float comparisons now pass under the new epsilon-based checks.
- No additional automated tests were added or removed; existing test suite status is fully green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a9631388832d904af0489c4a5c97)