### PR TITLE
Fix selected Clippy warnings

### DIFF
--- a/src/alm/cashaccount.rs
+++ b/src/alm/cashaccount.rs
@@ -189,9 +189,9 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        cash_account.iter().for_each(|(date, amount)| {
+        for (date, amount) in cash_account.iter() {
             println!("{date}: {amount}");
-        });
+        }
         Ok(())
     }
 
@@ -248,9 +248,9 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        cash_account.iter().for_each(|(date, amount)| {
+        for (date, amount) in cash_account.iter() {
             println!("{date}: {amount}");
-        });
+        }
         Ok(())
     }
 }

--- a/src/core/marketstore.rs
+++ b/src/core/marketstore.rs
@@ -178,10 +178,9 @@ impl fmt::Display for MarketStore {
         let mut indice_name: String;
 
         for indice in all_indices {
-            indice_name = match indice.read_index() {
-                Ok(indice) => indice.name().unwrap_or_default(),
-                Err(_) => String::new(),
-            };
+            indice_name = indice
+                .read_index()
+                .map_or_else(|_| String::new(), |indice| indice.name().unwrap_or_default());
             if !indice_name.is_empty() {
                 indices_names.push(indice_name);
             }
@@ -195,7 +194,7 @@ impl fmt::Display for MarketStore {
             for indice_name in indices_names {
                 let indice_idx = indices_map
                     .get(&indice_name)
-                    .map_or_else(String::new, |idx| idx.to_string());
+                    .map_or_else(String::new, std::string::ToString::to_string);
 
                 msg.push_str(">> ");
                 msg.push_str(&indice_idx);

--- a/src/currencies/exchangeratestore.rs
+++ b/src/currencies/exchangeratestore.rs
@@ -99,6 +99,7 @@ impl ExchangeRateStore {
                     if dest == second_ccy {
                         mutable_cache.insert((first_ccy, second_ccy), new_rate);
                         mutable_cache.insert((second_ccy, first_ccy), 1.0 / new_rate);
+                        drop(mutable_cache);
                         return Ok(new_rate);
                     }
                     visited.insert(dest);
@@ -108,6 +109,7 @@ impl ExchangeRateStore {
                     if source == second_ccy {
                         mutable_cache.insert((first_ccy, second_ccy), new_rate);
                         mutable_cache.insert((second_ccy, first_ccy), 1.0 / new_rate);
+                        drop(mutable_cache);
                         return Ok(new_rate);
                     }
                     visited.insert(source);
@@ -115,6 +117,7 @@ impl ExchangeRateStore {
                 }
             }
         }
+        drop(mutable_cache);
         Err(AtlasError::NotFoundErr(format!(
             "No exchange rate found between {first_ccy:?} and {second_ccy:?}"
         )))
@@ -139,7 +142,7 @@ impl AdvanceExchangeRateStoreInTime for ExchangeRateStore {
         }
 
         let mut new_store = Self::new(date);
-        for ((ccy1, ccy2), fx) in self.exchange_rate_map.iter() {
+        for ((ccy1, ccy2), fx) in &self.exchange_rate_map {
             let compound_factor = index_store.currency_forescast_factor(*ccy1, *ccy2, date);
             match compound_factor {
                 Ok(cf) => new_store.add_exchange_rate(*ccy1, *ccy2, fx * cf),

--- a/src/instruments/makedoublerateinstrument.rs
+++ b/src/instruments/makedoublerateinstrument.rs
@@ -60,7 +60,7 @@ pub struct MakeDoubleRateInstrument {
 }
 
 impl MakeDoubleRateInstrument {
-    /// Creates a new instance of MakeDoubleRateInstrument with default values.
+    /// Creates a new instance of `MakeDoubleRateInstrument` with default values.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn new() -> Self {


### PR DESCRIPTION
### Motivation

- Address a set of Clippy lints to make code more idiomatic and eliminate warnings treated as errors. 
- Reduce mutex hold time in exchange rate traversal to avoid unnecessary resource contention. 
- Simplify test iteration code for clarity and to follow idiomatic Rust patterns. 
- Improve documentation formatting for a builder type.

### Description

- Replaced `match`/`if let` patterns with `Option::map_or_else` and a direct method reference in `src/core/marketstore.rs` to follow Clippy suggestions. 
- Shortened the lifetime of the exchange-rate cache lock and added explicit `drop(mutable_cache)` before early returns in `src/currencies/exchangeratestore.rs`, and iterated over `&self.exchange_rate_map` instead of using `.iter()`. 
- Rewrote `iter().for_each(...)` test prints in `src/alm/cashaccount.rs` to simple `for` loops. 
- Fixed a documentation comment by adding backticks around the type name in `src/instruments/makedoublerateinstrument.rs`.

### Testing

- Ran `cargo test`. 
- All unit tests passed: `202 passed; 0 failed`. 
- All doc-tests passed as well: `45 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ab2899a0832dbd76e65bd16e3545)