### PR TITLE
Fix selected Clippy warnings in schedule, instruments, and tests

### DIFF
--- a/src/alm/cashaccount.rs
+++ b/src/alm/cashaccount.rs
@@ -189,7 +189,7 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        for (date, amount) in cash_account.iter() {
+        for (date, amount) in &cash_account {
             println!("{date}: {amount}");
         }
         Ok(())
@@ -248,7 +248,7 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        for (date, amount) in cash_account.iter() {
+        for (date, amount) in &cash_account {
             println!("{date}: {amount}");
         }
         Ok(())

--- a/src/instruments/hybridrateinstrument.rs
+++ b/src/instruments/hybridrateinstrument.rs
@@ -184,10 +184,10 @@ impl HybridRateInstrument {
 
 impl HasCurrency for HybridRateInstrument {
     fn currency(&self) -> Result<Currency> {
-        match self.currency {
-            Some(currency) => Ok(currency),
-            None => Err(AtlasError::NotFoundErr("Currency not found".to_string())),
-        }
+        self.currency.map_or_else(
+            || Err(AtlasError::NotFoundErr("Currency not found".to_string())),
+            Ok,
+        )
     }
 }
 

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -151,7 +151,7 @@ impl Instrument {
             Self::FixedRateInstrument(fri) => fri.structure(),
             Self::FloatingRateInstrument(fri) => fri.structure(),
             Self::HybridRateInstrument(hri) => hri.structure(),
-            _ => todo!(),
+            Self::DoubleRateInstrument(_) => todo!(),
         }
     }
 
@@ -259,7 +259,7 @@ impl Instrument {
             Self::FloatingRateInstrument(fri) => fri.set_forecast_curve_id(id),
             Self::HybridRateInstrument(hri) => hri.set_forecast_curve_id(id),
             Self::DoubleRateInstrument(dri) => dri.set_forecast_curve_id(id),
-            _ => {}
+            Self::FixedRateInstrument(_) => {}
         }
     }
 

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -379,13 +379,11 @@ impl MakeSchedule {
                 | DateGenerationRule::TwentiethIMM
                 | DateGenerationRule::OldCDS
                 | DateGenerationRule::CDS
-                | DateGenerationRule::CDS2015 => {
+                | DateGenerationRule::CDS2015
+                | DateGenerationRule::ThirdWednesdayInclusive => {
                     return Err(AtlasError::MakeScheduleErr(
                         "first date incompatible with date generation rule".to_string(),
                     ));
-                }
-                _ => {
-                    return Err(AtlasError::MakeScheduleErr("unknown rule".to_string()));
                 }
             }
         }
@@ -413,13 +411,11 @@ impl MakeSchedule {
                 | DateGenerationRule::TwentiethIMM
                 | DateGenerationRule::OldCDS
                 | DateGenerationRule::CDS
-                | DateGenerationRule::CDS2015 => {
+                | DateGenerationRule::CDS2015
+                | DateGenerationRule::ThirdWednesdayInclusive => {
                     return Err(AtlasError::MakeScheduleErr(
                         "next to last date incompatible with date generation rule".to_string(),
                     ));
-                }
-                _ => {
-                    return Err(AtlasError::MakeScheduleErr("unknown rule".to_string()));
                 }
             }
         }
@@ -447,18 +443,16 @@ impl MakeSchedule {
                         Some(self.convention),
                         self.end_of_month,
                     );
-                    if temp != self.next_to_last_date {
-                        self.is_regular.insert(0, false);
-                    } else {
-                        self.is_regular.insert(0, true);
-                    }
+                    self.is_regular
+                        .insert(0, temp == self.next_to_last_date);
                     seed = self.next_to_last_date;
                 }
 
-                let mut exit_date = self.effective_date;
-                if self.first_date != Date::empty() {
-                    exit_date = self.first_date;
-                }
+                let exit_date = if self.first_date != Date::empty() {
+                    self.first_date
+                } else {
+                    self.effective_date
+                };
 
                 loop {
                     let temp = null_calendar.advance(
@@ -575,11 +569,11 @@ impl MakeSchedule {
                     }
                 }
 
-                let mut exit_date = self.termination_date;
-
-                if self.next_to_last_date != Date::empty() {
-                    exit_date = self.next_to_last_date;
-                }
+                let exit_date = if self.next_to_last_date != Date::empty() {
+                    self.next_to_last_date
+                } else {
+                    self.termination_date
+                };
 
                 loop {
                     let temp = null_calendar.advance(
@@ -659,7 +653,7 @@ impl MakeSchedule {
                 );
             }
         } else if self.rule == DateGenerationRule::ThirdWednesdayInclusive {
-            for date in self.dates.iter_mut() {
+            for date in &mut self.dates {
                 *date = Date::nth_weekday(3, Weekday::Wednesday, date.month(), date.year());
             }
         }


### PR DESCRIPTION
### Motivation

- Reduce Clippy warnings and make code more idiomatic without changing public APIs.
- Improve readability and correctness of schedule generation logic and pattern matches.
- Replace non-idiomatic iteration and match constructs with clearer Rust idioms.

### Description

- Use reference iteration in cash account tests by iterating `for (date, amount) in &cash_account` to avoid explicit `.iter()` patterns in `src/alm/cashaccount.rs`.
- Make instrument match arms explicit and avoid wildcard matches by handling `DoubleRateInstrument` explicitly (kept as `todo!()` for structure) and refining `set_forecast_curve_id` branches in `src/instruments/instrument.rs`.
- Replace manual `match` on `Option` with `map_or_else` in `HybridRateInstrument::currency` to return a clearer `Err`/`Ok` in `src/instruments/hybridrateinstrument.rs`.
- Simplify `MakeSchedule::build` flow in `src/time/schedule.rs` by adding `ThirdWednesdayInclusive` to incompatible-rule checks, using expression-style `exit_date` assignments, replacing redundant `if/else` with direct boolean inserts, and using `&mut self.dates` for in-place iteration.

### Testing

- Ran `cargo test` to validate the changes.
- All unit tests passed: `202` tests succeeded with `0` failures.
- All doc-tests passed: `45` tests succeeded with `0` failures.
- The test run finished successfully using the `test` profile (`cargo test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963afa7a010832d8ac7b22f870c9620)