### PR TITLE
Fix clippy warnings and simplify visitors, instruments, and schedule logic

### DIFF
--- a/src/alm/cashaccount.rs
+++ b/src/alm/cashaccount.rs
@@ -189,7 +189,7 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        for (date, amount) in cash_account.iter() {
+        for (date, amount) in &cash_account {
             println!("{date}: {amount}");
         }
         Ok(())
@@ -248,7 +248,7 @@ mod tests {
         ];
         let cash_account = cash_account.cash_account_evolution(evals_dates)?;
 
-        for (date, amount) in cash_account.iter() {
+        for (date, amount) in &cash_account {
             println!("{date}: {amount}");
         }
         Ok(())

--- a/src/instruments/hybridrateinstrument.rs
+++ b/src/instruments/hybridrateinstrument.rs
@@ -184,10 +184,10 @@ impl HybridRateInstrument {
 
 impl HasCurrency for HybridRateInstrument {
     fn currency(&self) -> Result<Currency> {
-        match self.currency {
-            Some(currency) => Ok(currency),
-            None => Err(AtlasError::NotFoundErr("Currency not found".to_string())),
-        }
+        self.currency.map_or_else(
+            || Err(AtlasError::NotFoundErr("Currency not found".to_string())),
+            Ok,
+        )
     }
 }
 

--- a/src/instruments/instrument.rs
+++ b/src/instruments/instrument.rs
@@ -151,7 +151,7 @@ impl Instrument {
             Self::FixedRateInstrument(fri) => fri.structure(),
             Self::FloatingRateInstrument(fri) => fri.structure(),
             Self::HybridRateInstrument(hri) => hri.structure(),
-            _ => todo!(),
+            Self::DoubleRateInstrument(_) => todo!(),
         }
     }
 
@@ -259,7 +259,7 @@ impl Instrument {
             Self::FloatingRateInstrument(fri) => fri.set_forecast_curve_id(id),
             Self::HybridRateInstrument(hri) => hri.set_forecast_curve_id(id),
             Self::DoubleRateInstrument(dri) => dri.set_forecast_curve_id(id),
-            _ => {}
+            Self::FixedRateInstrument(_) => {}
         }
     }
 

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -379,13 +379,11 @@ impl MakeSchedule {
                 | DateGenerationRule::TwentiethIMM
                 | DateGenerationRule::OldCDS
                 | DateGenerationRule::CDS
-                | DateGenerationRule::CDS2015 => {
+                | DateGenerationRule::CDS2015
+                | DateGenerationRule::ThirdWednesdayInclusive => {
                     return Err(AtlasError::MakeScheduleErr(
                         "first date incompatible with date generation rule".to_string(),
                     ));
-                }
-                _ => {
-                    return Err(AtlasError::MakeScheduleErr("unknown rule".to_string()));
                 }
             }
         }
@@ -413,13 +411,11 @@ impl MakeSchedule {
                 | DateGenerationRule::TwentiethIMM
                 | DateGenerationRule::OldCDS
                 | DateGenerationRule::CDS
-                | DateGenerationRule::CDS2015 => {
+                | DateGenerationRule::CDS2015
+                | DateGenerationRule::ThirdWednesdayInclusive => {
                     return Err(AtlasError::MakeScheduleErr(
                         "next to last date incompatible with date generation rule".to_string(),
                     ));
-                }
-                _ => {
-                    return Err(AtlasError::MakeScheduleErr("unknown rule".to_string()));
                 }
             }
         }
@@ -447,18 +443,16 @@ impl MakeSchedule {
                         Some(self.convention),
                         self.end_of_month,
                     );
-                    if temp != self.next_to_last_date {
-                        self.is_regular.insert(0, false);
-                    } else {
-                        self.is_regular.insert(0, true);
-                    }
+                    self.is_regular
+                        .insert(0, temp == self.next_to_last_date);
                     seed = self.next_to_last_date;
                 }
 
-                let mut exit_date = self.effective_date;
-                if self.first_date != Date::empty() {
-                    exit_date = self.first_date;
-                }
+                let exit_date = if self.first_date != Date::empty() {
+                    self.first_date
+                } else {
+                    self.effective_date
+                };
 
                 loop {
                     let temp = null_calendar.advance(
@@ -575,11 +569,11 @@ impl MakeSchedule {
                     }
                 }
 
-                let mut exit_date = self.termination_date;
-
-                if self.next_to_last_date != Date::empty() {
-                    exit_date = self.next_to_last_date;
-                }
+                let exit_date = if self.next_to_last_date != Date::empty() {
+                    self.next_to_last_date
+                } else {
+                    self.termination_date
+                };
 
                 loop {
                     let temp = null_calendar.advance(
@@ -659,7 +653,7 @@ impl MakeSchedule {
                 );
             }
         } else if self.rule == DateGenerationRule::ThirdWednesdayInclusive {
-            for date in self.dates.iter_mut() {
+            for date in &mut self.dates {
                 *date = Date::nth_weekday(3, Weekday::Wednesday, date.month(), date.year());
             }
         }

--- a/src/visitors/cashflowaggregationvisitor.rs
+++ b/src/visitors/cashflowaggregationvisitor.rs
@@ -53,7 +53,7 @@ impl CashflowsAggregatorConstVisitor {
     pub fn redemptions(&self) -> BTreeMap<Date, f64> {
         self.redemptions
             .lock()
-            .map_or_else(|poison| poison.into_inner(), |guard| guard)
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -61,7 +61,7 @@ impl CashflowsAggregatorConstVisitor {
     pub fn disbursements(&self) -> BTreeMap<Date, f64> {
         self.disbursements
             .lock()
-            .map_or_else(|poison| poison.into_inner(), |guard| guard)
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -69,7 +69,7 @@ impl CashflowsAggregatorConstVisitor {
     pub fn interest(&self) -> BTreeMap<Date, f64> {
         self.interest
             .lock()
-            .map_or_else(|poison| poison.into_inner(), |guard| guard)
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 }

--- a/src/visitors/durationconstvisitor.rs
+++ b/src/visitors/durationconstvisitor.rs
@@ -30,7 +30,7 @@ impl<'a> DurationConstVisitor<'a> {
     }
 }
 
-impl<'a, T: HasCashflows> ConstVisit<T> for DurationConstVisitor<'a> {
+impl<T: HasCashflows> ConstVisit<T> for DurationConstVisitor<'_> {
     type Output = Result<f64>;
     fn visit(&self, visitable: &T) -> Self::Output {
         let duration = visitable

--- a/src/visitors/npvconstvisitor.rs
+++ b/src/visitors/npvconstvisitor.rs
@@ -34,7 +34,7 @@ impl<'a> NPVConstVisitor<'a> {
     }
 }
 
-impl<'a, T: HasCashflows> ConstVisit<T> for NPVConstVisitor<'a> {
+impl<T: HasCashflows> ConstVisit<T> for NPVConstVisitor<'_> {
     type Output = Result<f64>;
     fn visit(&self, visitable: &T) -> Self::Output {
         let npv = visitable.cashflows().iter().try_fold(0.0, |acc, cf| {

--- a/src/visitors/parvaluevisitordoublerateinstrument.rs
+++ b/src/visitors/parvaluevisitordoublerateinstrument.rs
@@ -120,7 +120,7 @@ impl ConstVisit<DoubleRateInstrument> for ParValueConstVisitor<'_> {
             instrument
                 .cashflows()
                 .iter()
-                .cloned()
+                .copied()
                 .partition(|cf| cf.payment_date() <= change_rate_date);
         // buscar id de cashflow con fecha de pago igual a change rate date
         let id = first_part_cashflows

--- a/src/visitors/zspreadconstvisitor.rs
+++ b/src/visitors/zspreadconstvisitor.rs
@@ -49,7 +49,7 @@ struct SpreadedNPV<'a, T> {
     target: f64,
 }
 
-impl<'a, T> SpreadedNPV<'a, T>
+impl<T> SpreadedNPV<'_, T>
 where
     T: HasCashflows,
 {
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<'a, T> CostFunction for SpreadedNPV<'a, T>
+impl<T> CostFunction for SpreadedNPV<'_, T>
 where
     T: HasCashflows,
 {
@@ -106,19 +106,18 @@ where
             .cashflows()
             .iter()
             .try_fold(0.0, |acc, cf| -> Result<f64> {
-                match cf {
-                    Cashflow::Disbursement(_) => Ok(acc),
-                    _ => {
-                        let cf_npv = self.cashflow_npv(cf, *param)?;
-                        Ok(acc + cf_npv)
-                    }
+                if let Cashflow::Disbursement(_) = cf {
+                    Ok(acc)
+                } else {
+                    let cf_npv = self.cashflow_npv(cf, *param)?;
+                    Ok(acc + cf_npv)
                 }
             })?;
         Ok((npv - self.target).abs())
     }
 }
 
-impl<'a, T> ConstVisit<T> for ZSpreadConstVisitor<'a>
+impl<T> ConstVisit<T> for ZSpreadConstVisitor<'_>
 where
     T: HasCashflows,
 {


### PR DESCRIPTION
### Motivation

- Reduce Clippy warnings and make code more idiomatic without changing public APIs. 
- Improve readability and correctness of schedule generation and visitor logic. 
- Replace non-idiomatic iteration and match constructs with clearer Rust idioms. 

### Description

- Simplified mutex error handling in `CashflowsAggregatorConstVisitor` using `unwrap_or_else(std::sync::PoisonError::into_inner)`. 
- Elided explicit visitor lifetimes in `ConstVisit` impls for `DurationConstVisitor`, `NPVConstVisitor`, `ZSpreadConstVisitor`, and `ParValueConstVisitor` and simplified folding logic (`if let` instead of `match`). 
- Replaced `.cloned()` with `.copied()` when partitioning cashflows and simplified instrument pattern matches (e.g. explicit `DoubleRateInstrument` arm and refined `set_forecast_curve_id` branches). 
- Made schedule code clearer by adding `ThirdWednesdayInclusive` to incompatible-rule checks, using expression-style `exit_date` assignments, and iterating `&mut self.dates` for in-place updates, and updated tests to iterate by reference (`for (date, amount) in &cash_account`).

### Testing

- Ran `cargo test`. 
- All unit tests passed: `202` tests succeeded with `0` failures. 
- All doc-tests passed: `45` tests succeeded with `0` failures. 
- Overall test run finished successfully using the `test` profile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963afa7a010832d8ac7b22f870c9620)