### PR TITLE
Add FxOutrightForward alias for FX outright forward parsing parsing

### DIFF
--- a/src/quotes/quote.rs
+++ b/src/quotes/quote.rs
@@ -1093,6 +1093,10 @@ impl QuoteDetails {
                 "Identifier has fewer than 3 parts: {s}"
             )));
         }
+	// Previous accepted identifiers:
+	// "FxForwardOutright" | "ForwardOutright"
+	// Added "FxOutrightForward" to support existing test identifiers
+	// and maintain backward compatibility.
 
         match parts[0] {
             "OIS" => Self::parse_ois(s, &parts),
@@ -1104,7 +1108,7 @@ impl QuoteDetails {
             "Future" => Self::parse_future(s, &parts),
             "ConvexityAdjustment" => Self::parse_convexity_adjustment(s, &parts),
             "Swaption" => Self::parse_swaption(s, &parts),
-            "FxForwardOutright" | "ForwardOutright" => Self::parse_outright_forward(s, &parts),
+            "FxForwardOutright" | "FxOutrightForward" | "ForwardOutright" => Self::parse_outright_forward(s, &parts),
             "FloatFloatCrossCurrencySwap" => Self::parse_float_float_cross_currency_swap(s, &parts),
             "FxForwardPoints" | "ForwardPoints" => Self::parse_forward_points(s, &parts),
             "EquityCall" | "Call" => Self::parse_equity_call(s, &parts),


### PR DESCRIPTION
## Summary

This PR adds support for the `FxOutrightForward` identifier in the FX outright forward parsing logic, ensuring compatibility with existing systems and tests.

## Change

- Extended the identifier match set to include `FxOutrightForward`
- Reuses existing `parse_outright_forward` logic without modification
- Maintains backward compatibility with existing identifiers:
  - `FxForwardOutright`
  - `ForwardOutright`

## Rationale

Some upstream systems and tests reference `FxOutrightForward` as the identifier for FX outright forward instruments. This change ensures consistent parsing across all supported naming conventions.

## Backward Compatibility

- Fully backward compatible  
- No changes to existing parsing behavior  
- No breaking changes introduced  

## Risk Assessment

Low risk:
- Additive change only
- No modifications to existing parsing logic
- No impact on other instrument types

## Testing

- Existing test suite passes
- Manual validation of identifier parsing confirms expected behavior