### PR TITLE
refactor: remove unused self from build_one in volatility builders

### DIFF
--- a/src/volatility/volatilitycubebuilder.rs
+++ b/src/volatility/volatilitycubebuilder.rs
@@ -42,7 +42,7 @@ impl VolatilityCubeBuilder {
         let mut cubes = HashMap::new();
 
         for spec in &self.specs {
-            let (cube, labels) = self.build_one(spec, selector, level, reference_date)?;
+            let (cube, labels) = Self::build_one(spec, selector, level, reference_date)?;
             let element = VolatilityCubeElement::new(
                 spec.market_index().clone(),
                 Rc::new(RefCell::new(cube.with_labels(&labels))),
@@ -53,9 +53,7 @@ impl VolatilityCubeBuilder {
         Ok(cubes)
     }
 
-    #[allow(clippy::unused_self)]
     fn build_one(
-        &self,
         spec: &VolatilityCubeConfiguration,
         selector: &impl QuoteSelector,
         level: Level,

--- a/src/volatility/volatilitysurfacebuilder.rs
+++ b/src/volatility/volatilitysurfacebuilder.rs
@@ -41,7 +41,7 @@ impl VolatilitySurfaceBuilder {
         let mut surfaces = HashMap::new();
 
         for spec in &self.specs {
-            let (surface, labels) = self.build_one(spec, selector, level, reference_date)?;
+            let (surface, labels) = Self::build_one(spec, selector, level, reference_date)?;
             let element = VolatilitySurfaceElement::new(
                 spec.market_index().clone(),
                 Rc::new(RefCell::new(surface.with_labels(&labels))),
@@ -52,9 +52,7 @@ impl VolatilitySurfaceBuilder {
         Ok(surfaces)
     }
 
-    #[allow(clippy::unused_self)]
     fn build_one(
-        &self,
         spec: &VolatilitySurfaceConfiguration,
         selector: &impl QuoteSelector,
         level: Level,


### PR DESCRIPTION
The `build_one` private helper in `VolatilitySurfaceBuilder` and `VolatilityCubeBuilder` took `&self` but never accessed any field on it. This forced a `#[allow(clippy::unused_self)]` suppression on each. Dropping the receiver and calling `Self::build_one` instead cleans that up.

Files changed: `src/volatility/volatilitysurfacebuilder.rs`, `src/volatility/volatilitycubebuilder.rs`

64 tests pass before and after, clippy clean before and after.