### PR TITLE
use digit separator in float literal

### DIFF
--- a/src/instruments/cashflows/makeleg.rs
+++ b/src/instruments/cashflows/makeleg.rs
@@ -607,7 +607,7 @@ where
                     .ok_or_else(|| QSError::ValueNotSetErr("Redemptions".into()))?;
                 let notional = disbursements.values().fold(0.0, |acc, x| acc + x).abs();
                 let redemption = redemptions.values().fold(0.0, |acc, x| acc + x).abs();
-                if (notional - redemption).abs() > 0.000001 {
+                if (notional - redemption).abs() > 0.000_001 {
                     return Err(QSError::InvalidValueErr(
                         "Notional and redemption must be equal".into(),
                     ));


### PR DESCRIPTION
Adds an underscore separator to the float literal `0.000001` in `makeleg.rs` so it reads as `0.000_001`, per the clippy `unreadable_literal` lint.

Files changed: `src/instruments/cashflows/makeleg.rs`

`cargo test`: 64 passed, 0 failed (unchanged). `cargo clippy -W clippy::all`: no warnings.

Not changed: any logic, thresholds, or observable behaviour.